### PR TITLE
Fix: Link Sharing Truncation & SEO Indexing Failures

### DIFF
--- a/src/app/docs/[[...slug]]/page.tsx
+++ b/src/app/docs/[[...slug]]/page.tsx
@@ -64,7 +64,13 @@ export async function generateMetadata({
   return {
     title: page.data.title,
     description: page.data.description,
+    alternates: {
+      canonical: slug ? `/docs/${slug.join("/")}` : "/docs",
+    },
     openGraph: {
+      url: slug
+        ? `https://www.envault.tech/docs/${slug.join("/")}`
+        : "https://www.envault.tech/docs",
       images: [
         `/api/og?title=${encodeURIComponent(page.data.title as string)}&section=Docs&description=${encodeURIComponent(page.data.description as string)}`,
       ],

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,9 +49,6 @@ export const metadata: Metadata = {
     "team collaboration security",
     "developer tools",
   ],
-  alternates: {
-    canonical: "/",
-  },
   authors: [{ name: "Envault Team" }],
   creator: "Envault",
   verification: {
@@ -60,7 +57,6 @@ export const metadata: Metadata = {
   openGraph: {
     type: "website",
     locale: "en_US",
-    url: "https://www.envault.tech",
     title: "Envault - Secure Environment Variables",
     description:
       "Manage your environment variables securely with Envault. End-to-end encryption for your peace of mind.",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,11 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Envault - Secure Environment Variable Management",
   description: "End-to-end encrypted secret manager for your entire team.",
+  alternates: {
+    canonical: "/",
+  },
   openGraph: {
+    url: "https://www.envault.tech",
     images: [
       "/api/og?title=Envault&description=Secure%20Environment%20Variable%20Management",
     ],

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,17 @@
 import { MetadataRoute } from 'next'
+import { loadedSource } from '@/lib/source'
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = 'https://www.envault.tech'
+
+  const pages = loadedSource.getPages()
+
+  const docsSitemap: MetadataRoute.Sitemap = pages.map((page) => ({
+    url: `${baseUrl}${page.url}`,
+    lastModified: new Date(),
+    changeFrequency: 'weekly',
+    priority: 0.9,
+  }))
 
   return [
     {
@@ -28,5 +38,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'yearly',
       priority: 0.5,
     },
+    ...docsSitemap,
   ]
 }


### PR DESCRIPTION
## Description

- closes #59 


This PR fixes a critical issue where sharing a specific page link (like `envault.tech/docs`) via Android's native share resulted in truncating the path, copying only the root domain (`envault.tech`). It also resolves the persistent Google Site Indexing crawl errors. 

The root cause of these issues was the global `alternates.canonical` and `openGraph.url` properties being hardcoded to the root `"/"` inside [src/app/layout.tsx](cci:7://file:///d:/ED/Envault/src/app/layout.tsx:0:0-0:0). Due to Next.js 13+ App Router's metadata merging behavior, these incorrect static tags were being forcefully inherited by every subpage across the application, causing crawlers to mark docs pages as duplicates of the homepage.

Additionally, this PR updates [sitemap.ts](cci:7://file:///d:/ED/Envault/src/app/sitemap.ts:0:0-0:0) to dynamically map and expose all documentation pages using Fumadocs.

## Changes Made
- **[Removed]** Hardcoded `alternates.canonical` and `openGraph.url` from the root [src/app/layout.tsx](cci:7://file:///d:/ED/Envault/src/app/layout.tsx:0:0-0:0).
- **[Added]** Explicit canonical and open-graph URL metadata to the homepage ([src/app/page.tsx](cci:7://file:///d:/ED/Envault/src/app/page.tsx:0:0-0:0)).
- **[Added]** Dynamic metadata injection in [src/app/docs/[[...slug]]/page.tsx](cci:7://file:///d:/ED/Envault/src/app/docs/%5B%5B...slug%5D%5D/page.tsx:0:0-0:0) that constructs the correct `alternates.canonical` and `openGraph.url` based on the active doc route slug.
- **[Updated]** [src/app/sitemap.ts](cci:7://file:///d:/ED/Envault/src/app/sitemap.ts:0:0-0:0) to fetch all routes via `loadedSource.getPages()` and inject them into the sitemap array to aid Googlebot discovery.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] SEO / Discoverability Improvement

## Checklist:
- [x] I have performed a self-review of my own code
- [x] Checked local HTML `<head>` payload ensuring the correct `<link rel="canonical">` and `<meta property="og:url">` are rendered
- [x] Verified `http://localhost:3000/sitemap.xml` dynamically lists sub-documentation routes
- [x] Ran `npm run build` to verify there are no Next.js static generation errors
