### PR TITLE
feat: Introduce `RootRefreshHandler` to trigger a full page refresh when navigating away from docs via browser history.

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { getServerOS } from "@/lib/os";
 import { ViewTransitions } from "next-view-transitions";
 import { headers } from "next/headers";
 import { SystemStatusBanner } from "@/components/ui/system-status-banner";
+import { RootRefreshHandler } from "@/components/RootRefreshHandler";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.envault.tech"),
@@ -137,6 +138,7 @@ export default async function RootLayout({
               }),
             }}
           />
+          <RootRefreshHandler />
           <ThemeProvider
             attribute="class"
             defaultTheme="light"

--- a/src/components/RootRefreshHandler.tsx
+++ b/src/components/RootRefreshHandler.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+
+export function RootRefreshHandler() {
+  const pathname = usePathname();
+  const lastPathname = useRef(pathname);
+
+  // Update the ref whenever the pathname changes normally
+  useEffect(() => {
+    lastPathname.current = pathname;
+  }, [pathname]);
+
+  useEffect(() => {
+    // Listen for browser back/forward buttons
+    const handlePopState = () => {
+      // If we were in /docs and are now going back to a non-docs page
+      if (
+        lastPathname.current?.startsWith("/docs") &&
+        !window.location.pathname.startsWith("/docs")
+      ) {
+        window.location.reload();
+      }
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Description

Fixes #69.

This PR resolves the critical rendering bug where the 3D `<Canvas>` WebGL context would crash and Framer Motion elements (like the Hero text and Navbar) would get stuck at `opacity: 0` when navigating back from the Documentation pages to the Landing or Privacy pages.

**Root Cause:**
Next.js client-side history traversal (coupled with `next-view-transitions`) skips native browser reloading. When a user clicks the back button from `/docs`, the DOM state snapshots force complex elements (WebGL and `AnimatePresence`) into a broken or invisible state because they fail to properly reinitialize their animation lifecycles. 

**Solution:**
Since the `pageshow` and performance navigation APIs do not reliably fire during Next.js client-side routing, we implemented a global hardware refresh fallback.
- Added [RootRefreshHandler](cci:1://file:///Users/dinanath/Documents/Envault/src/components/RootRefreshHandler.tsx:5:0-33:1), a seamless `<script>`-level client component inside the root [layout.tsx](cci:7://file:///Users/dinanath/Documents/Envault/src/app/layout.tsx:0:0-0:0). 
- The handler mounts globally and directly binds to `window.addEventListener('popstate')`, listening to the lowest-level browser history API.
- We track the previous route securely. If a popstate event is detected moving the user from *inside* `/docs` to *outside* of `/docs` (e.g., the landing page `/` or `/privacy`), it intercepts the render cycle and triggers an immediate `window.location.reload()`.

This forcefully drops the frozen snapshot state and reconstructs the React tree, guaranteeing the entire 3D Scene and Framer configurations animate flawlessly upon returning to the main site.

## Changes Made
- **Added:** [src/components/RootRefreshHandler.tsx](cci:7://file:///Users/dinanath/Documents/Envault/src/components/RootRefreshHandler.tsx:0:0-0:0) - Popstate event listener logic to track routes and dispatch reloads escaping `/docs`.
- **Modified:** [src/app/layout.tsx](cci:7://file:///Users/dinanath/Documents/Envault/src/app/layout.tsx:0:0-0:0) - Injected `<RootRefreshHandler />` component into the `<body>` so it runs continuously across all page navigations.

## Testing Instructions
1. Navigate to `/` (Landing Page). Verify the 3D Scene and Hero texts render.
2. Click the Docs link to navigate to `/docs`.
3. Click the browser Back button.
4. Verify the browser forces a native reload, and the 3D Scene / Hero texts are instantly restored to a perfect visual state.
5. Try navigating deep into the Docs (`/docs/quick-start`), then back multiple times. Returning to the main site should consistently force the refresh.