### PR TITLE
feat: enhance GitHub integration for auto-approval of viewer access and update documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,13 +15,32 @@ ENCRYPTION_KEY=your_64_character_hex_encryption_key_here
 ## Supabase Service Role Key (Required)
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key_here
 
-# Redis (Upstash)
+## Redis (Upstash)
 UPSTASH_REDIS_REST_URL=your_upstash_redis_rest_url_here
 UPSTASH_REDIS_REST_TOKEN=your_upstash_redis_rest_token_here
 
-# Resend (Email)
+## Application URLs
+# Optional; used for constructing links, redirecting, and CLI
+NEXT_PUBLIC_APP_URL=https://localhost:3000
+ENVAULT_CLI_URL=https://localhost:3000/api/cli
+
+## Scheduling
+# Secret used to authenticate incoming cron requests
+CRON_SECRET=your_secure_random_string_here
+
+## GitHub integration
+# Provide your GitHub App credentials if you plan to use repository
+# auto-approval or other GitHub features.
+NEXT_PUBLIC_GITHUB_APP_NAME=your_github_app_slug
+ENVAULT_GITHUB_APP_CLIENT_ID=your_github_app_client_id
+ENVAULT_GITHUB_APP_CLIENT_SECRET=your_github_app_client_secret
+# Private key may contain literal \n characters for newlines
+ENVAULT_GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...your key...\n-----END RSA PRIVATE KEY-----"
+ENVAULT_GITHUB_WEBHOOK_SECRET=your_github_webhook_secret
+
+## Resend (Email)
 RESEND_API_KEY=your_resend_api_key_here
 EMAIL_DOMAIN=your_configured_email
 
-# HMAC Secret for API Request Signing
+## HMAC Secret for API Request Signing
 NEXT_PUBLIC_API_SIGNATURE_SALT=your_secure_random_hmac_secret_here

--- a/content/docs/cli/commands.mdx
+++ b/content/docs/cli/commands.mdx
@@ -75,7 +75,7 @@ File resolution (if `--file` not provided):
 
 ### Access Request Flow
 
-If the project has a GitHub repository linked and you are a collaborator on that repository, `pull` automatically grants you **Viewer** access and returns the secrets without any manual invite.
+If the project has a GitHub repository linked and you are a collaborator on that repository, `pull` automatically and **permanently** grants you `Viewer` membership in that project. Your account is recorded in the project's access list — no manual invite or owner approval required. Subsequent commands like `envault status` work immediately, and the project appears in your "Shared with me" dashboard.
 
 If you do not have access and are not a recognized GitHub collaborator, the CLI prompts:
 

--- a/content/docs/core/access-control.mdx
+++ b/content/docs/core/access-control.mdx
@@ -64,12 +64,20 @@ Every action taken by a user is logged. Owners can view the **Audit Log** in the
 
 ## Just-in-Time (JIT) Access via GitHub
 
-When a project is linked to a GitHub repository, Envault can automatically grant **Viewer** access to developers the moment they run `envault pull` - no manual invite needed.
+When a project is linked to a GitHub repository, Envault can automatically grant **Viewer** access to developers the moment they run `envault pull` — no manual invite or owner approval needed.
 
 **How it works:**
 1. A developer runs `envault pull` without an existing project membership.
 2. Envault checks if their GitHub account is a collaborator on the linked repository.
-3. If yes → they are auto-granted the `viewer` role and receive their secrets.
+3. If yes → they are **permanently registered** as a `Viewer` in the project's access list and immediately receive their secrets.
 4. If no → the CLI offers to submit an access request to the project owner.
+
+<Callout type="info">
+  **GitHub Collaborators bypass the "Pending Approval" flow entirely.** Once
+  auto-granted, the user is a full `Viewer` member of the project. They will
+  see the project in their "Shared with me" dashboard, can run subsequent CLI
+  commands like `envault status` without errors, and the Project Owner can view
+  and manage their permissions in the project's access list.
+</Callout>
 
 See the [GitHub Integration](/docs/guides/github-integration) guide for setup instructions.

--- a/src/app/api/cli/projects/[projectId]/secrets/route.ts
+++ b/src/app/api/cli/projects/[projectId]/secrets/route.ts
@@ -8,6 +8,7 @@ import { PushSecretsSchema } from "@/lib/schemas";
 import { getProjectRole } from "@/lib/permissions";
 import { resolveProjectEnvironment } from "@/lib/cli-environments";
 import { isGitHubCollaborator, getGitHubUsername } from "@/lib/github";
+import { cacheSet, CacheKeys, CACHE_TTL } from "@/lib/cache";
 
 export async function GET(
   request: Request,
@@ -139,12 +140,38 @@ export async function GET(
             );
 
             if (isCollaborator) {
-              // Auto-approve: add as viewer and return secrets
-              await supabase.from("project_members").insert({
-                project_id: projectId,
-                user_id: userId,
-                role: "viewer",
-              });
+              // Auto-approve: upsert as viewer so repeat calls are idempotent.
+              // `added_by` is set to the user themselves (self-granted via GitHub JIT).
+              const { error: memberError } = await supabase
+                .from("project_members")
+                .upsert(
+                  {
+                    project_id: projectId,
+                    user_id: userId,
+                    role: "viewer",
+                    added_by: userId,
+                  },
+                  { onConflict: "project_id,user_id" },
+                );
+
+              if (memberError) {
+                console.error(
+                  `[JIT] Failed to persist viewer role for user ${userId} on project ${projectId}:`,
+                  memberError.message,
+                );
+                return NextResponse.json(
+                  { error: "Failed to grant access. Please try again." },
+                  { status: 500 },
+                );
+              }
+
+              // Populate the role cache so subsequent status/pull calls don't
+              // hit the DB for this entry within the same cache window.
+              await cacheSet(
+                CacheKeys.userProjectRole(userId, projectId),
+                "viewer",
+                CACHE_TTL.PROJECT_ROLE,
+              );
 
               // Clean up any pending access request so the dashboard doesn't
               // show them as stuck - JIT approval supersedes a manual request.


### PR DESCRIPTION
## Summary

Fixes #82 — GitHub collaborators who ran `envault pull` received their secrets on the first call, but were never persisted to the project ACL, causing all subsequent CLI commands to fail with `403 Forbidden` and the project to be invisible on their dashboard.

## Root Cause

The `project_members` table schema defines `added_by uuid NOT NULL`. The JIT auto-grant block in the secrets `GET` route called `.insert()` without the `added_by` field, triggering a silent NOT NULL constraint violation in PostgreSQL. Because the result was never captured, the failure was swallowed — secrets were returned as if the grant had succeeded, but no row was ever written to the ACL.

## Changes

### `src/app/api/cli/projects/[projectId]/secrets/route.ts`

- **`insert` → `upsert` with `onConflict: "project_id,user_id"`** — makes the operation idempotent; a second `envault pull` or a concurrent race no longer produces a unique-constraint error.
- **Added `added_by: userId`** — satisfies the `NOT NULL` constraint. The user self-grants via GitHub JIT, so `added_by = userId` is semantically correct and consistent with the invite flow in `invite-actions.ts`.
- **Error captured and surfaced** — if the upsert fails, the request now returns `500` instead of silently continuing. This closes the dangerous gap where secrets were served without the ACL write actually succeeding.
- **Cache warm-up after successful upsert** — writes the `"viewer"` role directly into Redis (`user:{userId}:project:{projectId}:role`) so the immediately following `envault status` resolves from cache, not from an extra DB round-trip.

### `content/docs/core/access-control.mdx` · `content/docs/cli/commands.mdx`

Updated the JIT Access documentation to explicitly state that:
- GitHub Collaborators **bypass the manual "Pending Approval" owner flow entirely**.
- On their first `envault pull` they are **permanently registered** as a `Viewer` in the project's ACL.
- The project appears in their "Shared with me" dashboard immediately.
- Subsequent CLI commands (`envault status`, `envault pull`, etc.) work without any 403 errors.
- The Project Owner can see and manage their permissions in the access list.

## Testing

1. Ensure user is a GitHub collaborator on the linked repo but has **no** manual Envault project membership.
2. Run `envault pull` → secrets are returned 
3. Query `project_members` table → row exists with `role = viewer` and `added_by = user_id` 
4. Run `envault status` → succeeds without 403 
5. Log in to Envault dashboard → project appears under "Shared with me" 
6. Project Owner views access list → user is visible with `Viewer` role 
7. Run `envault pull` a second time (idempotency check) → succeeds, no duplicate row 

## Risk

Low. The change is scoped entirely to the JIT branch — users who already have membership hit a different code path and are unaffected. The `upsert` is strictly more robust than the previous `insert`.