### PR TITLE
feat: implement automatic git hygiene and audit command for environment files

### DIFF
--- a/cli-go/README.md
+++ b/cli-go/README.md
@@ -25,6 +25,7 @@ The Envault CLI has been rewritten in Go to provide:
 - 🛡️ **Role-Based Access**: Verifies permissions (Editor/Viewer) for all operations.
 - 🚥 **Graceful Interrupts**: Cleanly handles `Ctrl+C` in all interactive flows.
 - 📁 **Auto-Linking**: Automatically triggers project initialization if no project is linked.
+- 🚨 **Automatic Git Hygiene**: `init`/`pull` install a pre-commit hook (envault audit) and `pull`/`deploy` will refuse to run on git-tracked `.env` files, auto-updating `.gitignore` when appropriate.
 - 🔄 **Automatic Updates**: Non-blocking background checks to notify you when a new version is available.
 
 ## Installation

--- a/cli-go/cmd/audit.go
+++ b/cli-go/cmd/audit.go
@@ -1,0 +1,633 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/DinanathDash/Envault/cli-go/internal/ui"
+	"github.com/joho/godotenv"
+	"github.com/spf13/cobra"
+)
+
+// AuditIssue represents a single finding from the audit.
+type AuditIssue struct {
+	Level   string   `json:"level"`            // "error" | "warning"
+	Code    string   `json:"code"`             // machine-readable identifier
+	Message string   `json:"message"`          // human-readable description
+	Keys    []string `json:"keys,omitempty"`   // affected env keys, if applicable
+}
+
+// AuditSummary holds counts of errors and warnings.
+type AuditSummary struct {
+	Errors   int `json:"errors"`
+	Warnings int `json:"warnings"`
+}
+
+// AuditResult is the top-level result structure, used for both text and JSON output.
+type AuditResult struct {
+	Passed  bool         `json:"passed"`
+	Issues  []AuditIssue `json:"issues"`
+	Summary AuditSummary `json:"summary"`
+}
+
+// Flags
+var (
+	auditStrict      bool
+	auditFormat      string
+	auditInstallHook bool
+	auditTemplate    string
+	auditEnvFile     string
+)
+
+// placeholderRe matches common placeholder / unfilled values.
+var placeholderRe = regexp.MustCompile(
+	`(?i)^(your[_\-].*|todo|change[_\-]?me|replace[_\-]?me|<[^>]+>|\[[^\]]+\]|xxx+|placeholder|example[_\-].*|changeme|fixme|insert[_\- ].*here|add[_\- ].*here|put[_\- ].*here|n/?a|none|null|undefined|secret|password|token)$`,
+)
+
+var auditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Audit environment files for structural integrity and git safety",
+	Long: `Validate the structural integrity and git status of local environment files.
+
+Checks performed:
+  • .gitignore contains patterns that exclude .env files
+  • No .env files (non-templates) are tracked in the git tree
+  • Local .env keys match the template (.env.example by default)
+  • No keys have empty or placeholder values
+
+Use --install-hook to embed this audit into the local git pre-commit hook.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if auditInstallHook {
+			runInstallHook()
+			return
+		}
+		runAudit()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(auditCmd)
+	auditCmd.Flags().BoolVar(&auditStrict, "strict", false, "Treat warnings as errors (non-zero exit if any warnings)")
+	auditCmd.Flags().StringVar(&auditFormat, "format", "text", "Output format: text or json")
+	auditCmd.Flags().BoolVar(&auditInstallHook, "install-hook", false, "Install envault audit as a git pre-commit hook")
+	auditCmd.Flags().StringVar(&auditTemplate, "template", ".env.example", "Template file to validate parity against")
+	auditCmd.Flags().StringVar(&auditEnvFile, "file", ".env", "Local env file to audit")
+}
+
+// ─── Hook Installation ────────────────────────────────────────────────────────
+
+const hookMarker = "# envault-audit-hook"
+
+// installPreCommitHook is the shared, error-returning implementation used by
+// both `envault audit --install-hook` and `envault init` (automatic install).
+//
+// Returns:
+//   - alreadyInstalled: true when the marker was already present (no-op)
+//   - binPath: absolute path of the binary embedded in the hook
+//   - err: non-nil on any filesystem or binary-resolution failure
+func installPreCommitHook() (alreadyInstalled bool, binPath string, err error) {
+	// Not inside a git repo - silently skip rather than error during init.
+	if _, statErr := os.Stat(".git"); os.IsNotExist(statErr) {
+		return false, "", fmt.Errorf("no .git directory found")
+	}
+
+	// Resolve the absolute path of the currently running binary.
+	execPath, execErr := os.Executable()
+	if execErr != nil {
+		return false, "", fmt.Errorf("could not determine executable path: %w", execErr)
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(execPath); resolveErr == nil {
+		execPath = resolved
+	}
+	execPath, _ = filepath.Abs(execPath)
+
+	hooksDir := ".git/hooks"
+	hookPath := hooksDir + "/pre-commit"
+
+	if mkErr := os.MkdirAll(hooksDir, 0755); mkErr != nil {
+		return false, execPath, fmt.Errorf("could not create hooks directory: %w", mkErr)
+	}
+
+	var existing string
+	if data, readErr := os.ReadFile(hookPath); readErr == nil {
+		existing = string(data)
+	}
+
+	// Idempotency guard.
+	if strings.Contains(existing, hookMarker) {
+		return true, execPath, nil
+	}
+
+	var sb strings.Builder
+	if existing == "" {
+		sb.WriteString("#!/bin/sh\n")
+	} else {
+		sb.WriteString(existing)
+		if !strings.HasSuffix(existing, "\n") {
+			sb.WriteByte('\n')
+		}
+	}
+	sb.WriteString("\n")
+	sb.WriteString(hookMarker + "\n")
+	sb.WriteString(fmt.Sprintf("ENVAULT_BIN=%q\n", execPath))
+	sb.WriteString("if [ ! -x \"$ENVAULT_BIN\" ]; then\n")
+	sb.WriteString("  echo \"\"\n")
+	sb.WriteString("  echo \"envault pre-commit hook: Envault audit could not run.\"\n")
+	sb.WriteString("  echo \"Reason: binary not found at: $ENVAULT_BIN\"\n")
+	sb.WriteString("  echo \"Fix:    re-install the hook by running: envault audit --install-hook\"\n")
+	sb.WriteString("  echo \"\"\n")
+	sb.WriteString("  exit 1\n")
+	sb.WriteString("fi\n")
+	sb.WriteString("\"$ENVAULT_BIN\" audit --strict\n")
+
+	if writeErr := os.WriteFile(hookPath, []byte(sb.String()), 0755); writeErr != nil {
+		return false, execPath, fmt.Errorf("failed to write pre-commit hook: %w", writeErr)
+	}
+
+	return false, execPath, nil
+}
+
+// runInstallHook is the CLI-facing wrapper for `envault audit --install-hook`.
+// It calls installPreCommitHook and handles printing / os.Exit behaviour.
+func runInstallHook() {
+	alreadyInstalled, binPath, err := installPreCommitHook()
+	if err != nil {
+		if strings.Contains(err.Error(), "no .git directory") {
+			fmt.Println(ui.ColorRed("✖ No .git directory found. Run this command from the root of a git repository."))
+		} else {
+			fmt.Println(ui.ColorRed(fmt.Sprintf("✖ %v", err)))
+		}
+		os.Exit(1)
+	}
+	if alreadyInstalled {
+		fmt.Println(ui.ColorYellow("ℹ envault audit hook is already installed in .git/hooks/pre-commit"))
+		return
+	}
+	fmt.Println(ui.ColorGreen("✔ Pre-commit hook installed at .git/hooks/pre-commit"))
+	fmt.Printf("%s  %s\n", ui.ColorDim("  Binary:"), ui.ColorCyan(binPath))
+	fmt.Println(ui.ColorDim("  envault audit --strict will run automatically before each commit."))
+}
+
+// ─── Audit Runner ─────────────────────────────────────────────────────────────
+
+func runAudit() {
+	var issues []AuditIssue
+
+	issues = append(issues, checkGitignore()...)
+	issues = append(issues, checkTrackedEnvFiles()...)
+	issues = append(issues, checkParity()...)
+
+	// Strict mode: promote all warnings to errors.
+	if auditStrict {
+		for i := range issues {
+			if issues[i].Level == "warning" {
+				issues[i].Level = "error"
+			}
+		}
+	}
+
+	// Tally results.
+	errCount := 0
+	warnCount := 0
+	for _, issue := range issues {
+		switch issue.Level {
+		case "error":
+			errCount++
+		case "warning":
+			warnCount++
+		}
+	}
+
+	result := AuditResult{
+		Passed:  errCount == 0,
+		Issues:  issues,
+		Summary: AuditSummary{Errors: errCount, Warnings: warnCount},
+	}
+
+	switch auditFormat {
+	case "json":
+		data, _ := json.MarshalIndent(result, "", "  ")
+		fmt.Println(string(data))
+	default:
+		printAuditResult(result)
+	}
+
+	if !result.Passed {
+		os.Exit(1)
+	}
+}
+
+// ─── Check: .gitignore ────────────────────────────────────────────────────────
+
+func checkGitignore() []AuditIssue {
+	f, err := os.Open(".gitignore")
+	if err != nil {
+		return []AuditIssue{{
+			Level:   "warning",
+			Code:    "GITIGNORE_MISSING",
+			Message: ".gitignore file not found. Environment files may be accidentally committed.",
+		}}
+	}
+	defer f.Close()
+
+	// Patterns that adequately protect .env files.
+	sufficient := []string{".env", "*.env", ".env.*", "**/.env"}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+		for _, pat := range sufficient {
+			if line == pat {
+				return nil // at least one protective pattern found
+			}
+		}
+	}
+
+	return []AuditIssue{{
+		Level:   "error",
+		Code:    "GITIGNORE_ENV_MISSING",
+		Message: "No environment file pattern (e.g., .env, *.env, .env.*) found in .gitignore. Environment files may be accidentally committed.",
+	}}
+}
+
+// ─── Check: tracked .env files ───────────────────────────────────────────────
+
+func checkTrackedEnvFiles() []AuditIssue {
+	out, err := exec.Command("git", "ls-files").Output()
+	if err != nil {
+		// Not a git repo or git not available - skip silently.
+		return nil
+	}
+
+	var issues []AuditIssue
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" {
+			continue
+		}
+		if isTrackedEnvFile(name) {
+			issues = append(issues, AuditIssue{
+				Level:   "error",
+				Code:    "ENV_FILE_TRACKED",
+				Message: fmt.Sprintf("Environment file '%s' is tracked in the git tree and may expose secrets.", name),
+			})
+		}
+	}
+	return issues
+}
+
+// isTrackedEnvFile returns true when the path looks like a real env file
+// (not a template/example variant).
+func isTrackedEnvFile(name string) bool {
+	// Consider only the filename, not the directory part.
+	base := name
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		base = name[idx+1:]
+	}
+
+	// Must be ".env" itself, start with ".env.", or end with ".env".
+	isEnvFile := base == ".env" || strings.HasPrefix(base, ".env.") || strings.HasSuffix(base, ".env")
+	if !isEnvFile {
+		return false
+	}
+
+	// Exclude well-known template suffixes.
+	lower := strings.ToLower(base)
+	for _, token := range []string{"example", "sample", "template", "dist", "defaults", "test", "ci"} {
+		if strings.Contains(lower, token) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// ─── Shared safety helpers ────────────────────────────────────────────────────
+
+// isTrackedByGit returns true if path is currently tracked in the git index.
+// Returns false when git is unavailable or the working directory has no repo.
+func isTrackedByGit(path string) bool {
+	err := exec.Command("git", "ls-files", "--error-unmatch", path).Run()
+	return err == nil
+}
+
+// ensureGitignoreEntry guarantees the given filename is covered by at least
+// one pattern in .gitignore. If .gitignore does not exist it is created; if it
+// exists but has no covering pattern, the exact filename is appended.
+//
+// "Covered" means one of these lines already appears in the file:
+//
+//	.env   *.env   .env.*   **/.env   or an exact match of filename
+func ensureGitignoreEntry(filename string) (added bool, err error) {
+	// Strip any leading "./" from filename for comparison.
+	base := strings.TrimPrefix(filename, "./")
+
+	// Patterns that broadly cover standard .env files.
+	broadPatterns := []string{".env", "*.env", ".env.*", "**/.env"}
+
+	data, readErr := os.ReadFile(".gitignore")
+	if readErr == nil {
+		// File exists - scan line by line.
+		scanner := bufio.NewScanner(strings.NewReader(string(data)))
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			if line == base {
+				return false, nil // already covered by exact match
+			}
+			for _, pat := range broadPatterns {
+				if line == pat {
+					return false, nil // covered by a broad pattern
+				}
+			}
+		}
+
+		// Not covered - append the exact filename.
+		f, openErr := os.OpenFile(".gitignore", os.O_APPEND|os.O_WRONLY, 0644)
+		if openErr != nil {
+			return false, fmt.Errorf("could not open .gitignore: %w", openErr)
+		}
+		defer f.Close()
+
+		// Ensure we start on a new line.
+		if len(data) > 0 && data[len(data)-1] != '\n' {
+			if _, writeErr := f.WriteString("\n"); writeErr != nil {
+				return false, writeErr
+			}
+		}
+		if _, writeErr := f.WriteString(base + "\n"); writeErr != nil {
+			return false, writeErr
+		}
+		return true, nil
+	}
+
+	// .gitignore does not exist - create it.
+	if writeErr := os.WriteFile(".gitignore", []byte(base+"\n"), 0644); writeErr != nil {
+		return false, fmt.Errorf("could not create .gitignore: %w", writeErr)
+	}
+	return true, nil
+}
+
+// ─── Check: parity with template ─────────────────────────────────────────────
+
+func checkParity() []AuditIssue {
+	// 1. Attempt to read the template file.
+	templateEnv, err := godotenv.Read(auditTemplate)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []AuditIssue{{
+				Level:   "warning",
+				Code:    "TEMPLATE_MISSING",
+				Message: fmt.Sprintf("Template file '%s' not found. Parity check skipped.", auditTemplate),
+			}}
+		}
+		return []AuditIssue{{
+			Level:   "error",
+			Code:    "TEMPLATE_PARSE_ERROR",
+			Message: fmt.Sprintf("Could not parse template '%s': %s", auditTemplate, sanitizeParseErr(err)),
+		}}
+	}
+
+	// 2. Attempt to read the local env file.
+	localEnv, err := godotenv.Read(auditEnvFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []AuditIssue{{
+				Level:   "error",
+				Code:    "ENV_FILE_MISSING",
+				Message: fmt.Sprintf("Local env file '%s' not found.", auditEnvFile),
+			}}
+		}
+		return []AuditIssue{{
+			Level:   "error",
+			Code:    "ENV_FILE_PARSE_ERROR",
+			Message: fmt.Sprintf("Could not parse '%s': %s", auditEnvFile, sanitizeParseErr(err)),
+		}}
+	}
+
+	var issues []AuditIssue
+
+	// 3. Missing keys: present in template but absent in local.
+	var missingKeys []string
+	for k := range templateEnv {
+		if _, ok := localEnv[k]; !ok {
+			missingKeys = append(missingKeys, k)
+		}
+	}
+	if len(missingKeys) > 0 {
+		sort.Strings(missingKeys)
+		issues = append(issues, AuditIssue{
+			Level:   "error",
+			Code:    "MISSING_KEYS",
+			Message: fmt.Sprintf("%d key(s) defined in '%s' are missing from '%s'.", len(missingKeys), auditTemplate, auditEnvFile),
+			Keys:    missingKeys,
+		})
+	}
+
+	// 4. Orphaned keys: present in local but absent in template.
+	var orphanedKeys []string
+	for k := range localEnv {
+		if _, ok := templateEnv[k]; !ok {
+			orphanedKeys = append(orphanedKeys, k)
+		}
+	}
+	if len(orphanedKeys) > 0 {
+		sort.Strings(orphanedKeys)
+		issues = append(issues, AuditIssue{
+			Level:   "warning",
+			Code:    "ORPHANED_KEYS",
+			Message: fmt.Sprintf("%d key(s) in '%s' are not defined in the template '%s'.", len(orphanedKeys), auditEnvFile, auditTemplate),
+			Keys:    orphanedKeys,
+		})
+	}
+
+	// 5. Empty or placeholder values in local env.
+	var placeholderKeys []string
+	for k, v := range localEnv {
+		v = strings.TrimSpace(v)
+		if v == "" || placeholderRe.MatchString(v) {
+			placeholderKeys = append(placeholderKeys, k)
+		}
+	}
+	if len(placeholderKeys) > 0 {
+		sort.Strings(placeholderKeys)
+		issues = append(issues, AuditIssue{
+			Level:   "error",
+			Code:    "PLACEHOLDER_VALUES",
+			Message: fmt.Sprintf("%d key(s) in '%s' have empty or placeholder values.", len(placeholderKeys), auditEnvFile),
+			Keys:    placeholderKeys,
+		})
+	}
+
+	return issues
+}
+
+// ─── Text Renderer ────────────────────────────────────────────────────────────
+
+// issueSection maps each code to its display section.
+var issueSection = map[string]string{
+	"GITIGNORE_MISSING":     "git",
+	"GITIGNORE_ENV_MISSING": "git",
+	"ENV_FILE_TRACKED":      "git",
+	"TEMPLATE_MISSING":      "parity",
+	"TEMPLATE_PARSE_ERROR":  "parity",
+	"ENV_FILE_MISSING":      "parity",
+	"ENV_FILE_PARSE_ERROR":  "parity",
+	"MISSING_KEYS":          "parity",
+	"ORPHANED_KEYS":         "parity",
+	"PLACEHOLDER_VALUES":    "parity",
+}
+
+// sectionOrder defines display order and labels for sections.
+var sectionOrder = []struct {
+	key   string
+	label string
+}{
+	{"git", "GIT SAFETY"},
+	{"parity", "KEY PARITY"},
+}
+
+func printAuditResult(result AuditResult) {
+	const sepLen = 56
+	sep := ui.ColorDim(strings.Repeat("─", sepLen))
+
+	titleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("#22D3EE")).
+		Width(sepLen).
+		Align(lipgloss.Center)
+
+	sectionStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("#9CA3AF"))
+
+	fmt.Println()
+	fmt.Println(titleStyle.Render("ENVAULT AUDIT"))
+	fmt.Println(sep)
+
+	if len(result.Issues) == 0 {
+		fmt.Println()
+		fmt.Printf("  %s\n\n", ui.ColorGreen("✔  All checks passed. No issues found."))
+		fmt.Println(sep)
+		fmt.Printf("  %s\n", lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#34D399")).Render("✔  PASSED"))
+		fmt.Println(sep)
+		fmt.Println()
+		return
+	}
+
+	// Index issues by code for grouped rendering.
+	issueByCode := map[string]AuditIssue{}
+	for _, issue := range result.Issues {
+		issueByCode[issue.Code] = issue
+	}
+
+	for _, sec := range sectionOrder {
+		// Collect issues belonging to this section, in canonical order.
+		var secIssues []AuditIssue
+		for _, codeOrder := range []string{
+			"GITIGNORE_MISSING", "GITIGNORE_ENV_MISSING", "ENV_FILE_TRACKED",
+			"TEMPLATE_MISSING", "TEMPLATE_PARSE_ERROR", "ENV_FILE_MISSING", "ENV_FILE_PARSE_ERROR",
+			"MISSING_KEYS", "ORPHANED_KEYS", "PLACEHOLDER_VALUES",
+		} {
+			if issueSection[codeOrder] == sec.key {
+				if issue, ok := issueByCode[codeOrder]; ok {
+					secIssues = append(secIssues, issue)
+				}
+			}
+		}
+		if len(secIssues) == 0 {
+			continue
+		}
+
+		fmt.Println()
+		fmt.Printf("  %s\n", sectionStyle.Render(sec.label))
+		fmt.Println()
+
+		for _, issue := range secIssues {
+			var icon, badge, msg string
+			switch issue.Level {
+			case "error":
+				icon = ui.ColorRed("✖")
+				badge = lipgloss.NewStyle().
+					Bold(true).
+					Foreground(lipgloss.Color("#F87171")).
+					Render(issue.Code)
+				msg = ui.ColorRed(issue.Message)
+			case "warning":
+				icon = ui.ColorYellow("⚠")
+				badge = lipgloss.NewStyle().
+					Bold(true).
+					Foreground(lipgloss.Color("#FBBF24")).
+					Render(issue.Code)
+				msg = ui.ColorYellow(issue.Message)
+			default:
+				icon = ui.ColorBlue("ℹ")
+				badge = lipgloss.NewStyle().
+					Bold(true).
+					Foreground(lipgloss.Color("#60A5FA")).
+					Render(issue.Code)
+				msg = issue.Message
+			}
+
+			fmt.Printf("  %s  %s\n", icon, badge)
+			fmt.Printf("     %s\n", msg)
+			if len(issue.Keys) > 0 {
+				fmt.Println()
+				for _, k := range issue.Keys {
+					fmt.Printf("       %s  %s\n", ui.ColorDim("·"), k)
+				}
+			}
+			fmt.Println()
+		}
+	}
+
+	fmt.Println(sep)
+	if result.Passed {
+		passStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#34D399"))
+		fmt.Printf("  %s   %s\n",
+			passStyle.Render("✔  PASSED"),
+			ui.ColorDim(fmt.Sprintf("%d errors · %d warnings", result.Summary.Errors, result.Summary.Warnings)),
+		)
+	} else {
+		failStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F87171"))
+		fmt.Printf("  %s   %s\n",
+			failStyle.Render("✖  FAILED"),
+			ui.ColorDim(fmt.Sprintf("%d errors · %d warnings", result.Summary.Errors, result.Summary.Warnings)),
+		)
+	}
+	fmt.Println(sep)
+	fmt.Println()
+}
+
+// sanitizeParseErr trims godotenv error messages that embed raw file content
+// after the "near" keyword, producing a clean single-line diagnostic.
+func sanitizeParseErr(err error) string {
+	msg := err.Error()
+	if idx := strings.Index(msg, " near "); idx > 0 {
+		// Keep everything up to "near ..." but strip the file-content dump.
+		// Show only the first 60 chars of the "near" excerpt so users can
+		// spot which character caused the issue without a wall of text.
+		suffix := msg[idx+6:] // skip " near "
+		if len(suffix) > 60 {
+			suffix = suffix[:60] + "…"
+		}
+		return msg[:idx] + ` near "` + suffix + `"`
+	}
+	const maxLen = 120
+	if len(msg) > maxLen {
+		return msg[:maxLen] + "…"
+	}
+	return msg
+}

--- a/cli-go/cmd/deploy.go
+++ b/cli-go/cmd/deploy.go
@@ -37,6 +37,23 @@ var deployCmd = &cobra.Command{
 		targetEnv := resolveTargetEnvironment()
 		targetFile := resolveEnvFile(targetEnv, fileFlag)
 
+		// Hard gate: if the source file is tracked by git, the secrets are
+		// already (or will be) in git history. Block the deploy and tell the
+		// user exactly how to fix it - there is no safe way to proceed silently.
+		if isTrackedByGit(targetFile) {
+			fmt.Println()
+			fmt.Println(ui.ColorRed("  ✖  BLOCKED: " + targetFile + " is tracked in your git repository."))
+			fmt.Println(ui.ColorRed("     Your secrets may already be exposed in your git history."))
+			fmt.Println(ui.ColorYellow("     You must stop tracking this file before using Envault:"))
+			fmt.Println(ui.ColorCyan("       git rm --cached " + targetFile))
+			fmt.Println(ui.ColorCyan("       echo '" + targetFile + "' >> .gitignore"))
+			fmt.Println(ui.ColorCyan("       git commit -m 'stop tracking " + targetFile + "'"))
+			fmt.Println()
+			fmt.Println(ui.ColorYellow("     If secrets have already been committed, consider rotating them in Envault."))
+			fmt.Println()
+			os.Exit(1)
+		}
+
 		// 2. Read .env manually to be lenient
 		content, err := os.ReadFile(targetFile)
 		if err != nil {

--- a/cli-go/cmd/init.go
+++ b/cli-go/cmd/init.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/DinanathDash/Envault/cli-go/internal/project"
@@ -69,6 +70,25 @@ var initCmd = &cobra.Command{
 		}
 
 		fmt.Println(ui.ColorGreen(fmt.Sprintf("\n✔ Project linked! (ID: %s)", projectId)))
+
+		// Automatically install the audit pre-commit hook so the user never
+		// has to remember the separate --install-hook command.
+		alreadyInstalled, _, hookErr := installPreCommitHook()
+		switch {
+		case hookErr != nil && strings.Contains(hookErr.Error(), "no .git directory"):
+			// No git repo yet - print a clear, actionable reminder instead of silently skipping.
+			// The user may git init later and forget to add protection.
+			fmt.Println(ui.ColorYellow("  ⚠ No git repository detected."))
+			fmt.Println(ui.ColorYellow("    After running git init, protect your secrets by running:"))
+			fmt.Println(ui.ColorCyan("      envault audit --install-hook"))
+		case hookErr != nil:
+			// Any other filesystem error - surface as a soft warning.
+			fmt.Println(ui.ColorYellow(fmt.Sprintf("  ⚠ Could not install pre-commit hook: %v", hookErr)))
+		case alreadyInstalled:
+			fmt.Println(ui.ColorDim("  ✔ envault audit pre-commit hook already installed."))
+		default:
+			fmt.Println(ui.ColorGreen("  ✔ envault audit pre-commit hook installed - your commits are now protected."))
+		}
 	},
 }
 

--- a/cli-go/cmd/pull.go
+++ b/cli-go/cmd/pull.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/DinanathDash/Envault/cli-go/internal/api"
@@ -146,7 +147,22 @@ var pullCmd = &cobra.Command{
 			return
 		}
 
-		// 4. Write to .env
+		// 4. Hard gate: refuse to write if the target file is already tracked by git.
+		// Writing secrets into a tracked file would silently include them in the next commit.
+		if isTrackedByGit(targetFile) {
+			s.Stop()
+			fmt.Println()
+			fmt.Println(ui.ColorRed("  ✖  BLOCKED: " + targetFile + " is tracked in your git repository."))
+			fmt.Println(ui.ColorYellow("     Writing secrets into a tracked file would expose them in your git history."))
+			fmt.Println(ui.ColorYellow("     Fix this before pulling:"))
+			fmt.Println(ui.ColorCyan("       git rm --cached " + targetFile))
+			fmt.Println(ui.ColorCyan("       echo '" + targetFile + "' >> .gitignore"))
+			fmt.Println(ui.ColorCyan("       git commit -m 'stop tracking " + targetFile + "'"))
+			fmt.Println()
+			os.Exit(1)
+		}
+
+		// 5. Write to .env
 		f, err := os.Create(targetFile)
 		if err != nil {
 			s.Stop()
@@ -166,6 +182,28 @@ var pullCmd = &cobra.Command{
 
 		s.Stop()
 		fmt.Println(ui.ColorGreen(fmt.Sprintf("✔ Pulled %d secrets from %s into %s.", len(secretsResp.Secrets), targetEnv, targetFile)))
+
+		// Safety checkpoint: real secrets are now on disk.
+		// 1. Ensure .gitignore covers the written file - create/update it automatically.
+		giAdded, giErr := ensureGitignoreEntry(targetFile)
+		if giErr != nil {
+			fmt.Println(ui.ColorYellow(fmt.Sprintf("  ⚠ Could not update .gitignore: %v", giErr)))
+		} else if giAdded {
+			fmt.Println(ui.ColorGreen("  ✔ Added '" + targetFile + "' to .gitignore - it will not be committed."))
+		}
+
+		// 2. Attempt to install the pre-commit hook.
+		alreadyInstalled, _, hookErr := installPreCommitHook()
+		switch {
+		case hookErr != nil && strings.Contains(hookErr.Error(), "no .git directory"):
+			// No git repo yet - warn the user to run the hook installer after git init.
+			fmt.Println(ui.ColorYellow("  ⚠ No git repository detected. After git init, run:"))
+			fmt.Println(ui.ColorCyan("      envault audit --install-hook"))
+		case hookErr != nil:
+			fmt.Println(ui.ColorYellow(fmt.Sprintf("  ⚠ Could not install pre-commit hook: %v", hookErr)))
+		case !alreadyInstalled:
+			fmt.Println(ui.ColorGreen("  ✔ Pre-commit hook installed - secrets are protected from accidental commits."))
+		}
 	},
 }
 

--- a/content/docs/cli/commands.mdx
+++ b/content/docs/cli/commands.mdx
@@ -4,6 +4,7 @@ description: Full command reference for Envault CLI
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
+import { XCircle, ShieldOff, FileX, GitBranch } from "lucide-react";
 
 # CLI Commands
 
@@ -73,9 +74,31 @@ File resolution (if `--file` not provided):
 2. auto-detected `.env*` file
 3. fallback `.env`
 
+### Automatic safety on every pull
+
+Every time `pull` writes secrets to disk it runs three automatic safeguards:
+
+1. <XCircle className="inline w-4 h-4 mr-1 text-red-500" /> **Tracked-file hard block** — if the target file is already tracked in your git repository the command **refuses to write** anything. Overwriting a tracked file would silently include secrets in your next commit. The CLI prints the exact commands needed to untrack it before retrying.
+
+2. <FileX className="inline w-4 h-4 mr-1 text-yellow-500" /> **Auto-gitignore** — if the target file is not already covered by `.gitignore` (or `.gitignore` does not exist), the CLI adds an entry automatically. You will see a confirmation line whenever this happens.
+
+3. <GitBranch className="inline w-4 h-4 mr-1 text-green-500" /> **Pre-commit hook** — if a git repository is present and the audit hook has not been installed, it is installed automatically. If no git repository is detected yet the CLI reminds you to run `envault audit --install-hook` after `git init`.
+
+<Callout type="warn">
+  If `pull` is blocked because the target file is tracked, remove it from the git index first:
+
+  ```bash
+  git rm --cached .env
+  echo '.env' >> .gitignore
+  git commit -m 'stop tracking .env'
+  ```
+
+  Then re-run `envault pull`.
+</Callout>
+
 ### Access Request Flow
 
-If the project has a GitHub repository linked and you are a collaborator on that repository, `pull` automatically and **permanently** grants you `Viewer` membership in that project. Your account is recorded in the project's access list — no manual invite or owner approval required. Subsequent commands like `envault status` work immediately, and the project appears in your "Shared with me" dashboard.
+If the project has a GitHub repository linked and you are a collaborator on that repository, `pull` automatically and **permanently** grants you `Viewer` membership in that project. Your account is recorded in the project's access list - no manual invite or owner approval required. Subsequent commands like `envault status` work immediately, and the project appears in your "Shared with me" dashboard.
 
 If you do not have access and are not a recognized GitHub collaborator, the CLI prompts:
 
@@ -113,6 +136,18 @@ Flags:
 - `--file <path>`: local env file override
 - `--dry-run`: print what would be pushed
 - `-f, --force`: skip confirmation
+
+### Tracked-file hard block
+
+Before reading a single byte from your env file, `deploy` checks whether that file is tracked in git. If it is, the command **refuses to run** and prints:
+
+> <XCircle className="inline w-4 h-4 mr-1 text-red-500" /> **BLOCKED: `.env` is tracked in your git repository.** Your secrets may already be exposed in your git history.
+
+The CLI prints the exact `git rm --cached` commands needed to fix the situation and reminds you to rotate any secrets that may have been visible in your history.
+
+<Callout type="warn">
+  Once a secret has appeared in a git commit it is part of the repository history even after deletion. If `deploy` is blocked by this check, rotate the affected secrets in Envault after untracking the file.
+</Callout>
 
 ---
 
@@ -172,6 +207,48 @@ Offline behavior:
 - On timeout/network transport failures, `run` falls back to the last cached secrets for the same project+environment.
 - Auth/authorization/API errors (`401/403/404`) do not trigger cache fallback.
 - Optional override for slow networks/bootstrap: set `ENVAULT_RUN_TIMEOUT_SECONDS` (for example `10`) to increase the `run` fetch timeout.
+
+---
+
+## `audit`
+
+Make sure your local environment files are structurally valid and safe to commit. `audit` performs four checks:
+
+| Check | What it catches |
+|---|---|
+| **Git safety** | `.gitignore` missing or doesn't cover `.env` files |
+| **Git safety** | Any `.env` file (non-template) tracked in the git index |
+| **Key parity** | Keys in your local file that are missing from the template |
+| **Key parity** | Keys with empty or placeholder values (`TODO`, `your_api_key`, `<insert here>`, etc.) |
+
+```bash
+# run a quick check in your repository
+envault audit
+
+# specify a different file or template
+envault audit --file .env.staging --template .env.staging.example
+```
+
+### Strict mode & machine output
+
+- `--strict` upgrades all warnings to errors and will exit non-zero if any issue is found.
+- `--format=json` emits a structured JSON object suitable for CI pipelines.
+
+### Pre-commit hook
+
+The audit check can be embedded into a git pre-commit hook so every attempted commit is validated automatically:
+
+```bash
+envault audit --install-hook
+```
+
+The hook is idempotent (safe to run multiple times), preserves any existing content in `.git/hooks/pre-commit`, and embeds the **absolute path** of the binary that installed it - so git always invokes the correct version regardless of what is on `$PATH` at commit time.
+
+**You typically do not need to run this manually.** The hook is installed automatically when you run `envault init` (if a git repository is present) and whenever `envault pull` writes secrets for the first time in a new repository.
+
+<Callout type="info">
+  If you move or reinstall the Envault binary after installing the hook, re-run `envault audit --install-hook` to update the embedded path.
+</Callout>
 
 ---
 

--- a/content/docs/core/access-control.mdx
+++ b/content/docs/core/access-control.mdx
@@ -4,6 +4,7 @@ description: Manage team permissions with fine-grained roles.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
+import { ArrowRight } from "lucide-react";
 
 Envault allows you to control who has access to which projects using a **Role-Based Access Control (RBAC)** system.
 
@@ -64,13 +65,13 @@ Every action taken by a user is logged. Owners can view the **Audit Log** in the
 
 ## Just-in-Time (JIT) Access via GitHub
 
-When a project is linked to a GitHub repository, Envault can automatically grant **Viewer** access to developers the moment they run `envault pull` — no manual invite or owner approval needed.
+When a project is linked to a GitHub repository, Envault can automatically grant **Viewer** access to developers the moment they run `envault pull` - no manual invite or owner approval needed.
 
 **How it works:**
 1. A developer runs `envault pull` without an existing project membership.
 2. Envault checks if their GitHub account is a collaborator on the linked repository.
-3. If yes → they are **permanently registered** as a `Viewer` in the project's access list and immediately receive their secrets.
-4. If no → the CLI offers to submit an access request to the project owner.
+3. If yes <ArrowRight className="inline w-4 h-4 mx-1" /> they are **permanently registered** as a `Viewer` in the project's access list and immediately receive their secrets.
+4. If no <ArrowRight className="inline w-4 h-4 mx-1" /> the CLI offers to submit an access request to the project owner.
 
 <Callout type="info">
   **GitHub Collaborators bypass the "Pending Approval" flow entirely.** Once

--- a/content/docs/guides/ci-cd-integration.mdx
+++ b/content/docs/guides/ci-cd-integration.mdx
@@ -21,6 +21,38 @@ The safest way to inject secrets is to wrap your build command with `envault run
   **Security Guardrail**: To prevent accidental leakage of Service Tokens on developer machines, the CLI aggressively blocks Service Token (`ENVAULT_TOKEN`) usage unless a standard CI/CD environment variable (like `CI=true` or `GITHUB_ACTIONS=true`) is detected. Local authentication must use `envault login`.
 </Callout>
 
+### Automatic local safeguards
+
+Before you ever reach a CI pipeline, Envault enforces secret hygiene directly on the developer's machine through three automatic layers:
+
+| Trigger | Safeguard |
+|---|---|
+| `envault pull` | **Blocks** writing if the target `.env` file is already git-tracked |
+| `envault pull` | **Auto-adds** the file to `.gitignore` if not already covered |
+| `envault pull` / `envault init` | **Auto-installs** a git pre-commit hook that runs `envault audit --strict` before every commit |
+| `envault deploy` | **Blocks** reading if the source `.env` file is git-tracked |
+
+These gates fire silently on first use - no configuration required. The pre-commit hook prints the absolute path of the binary it uses, so version mismatches are always visible.
+
+<Callout type="info">
+  The pre-commit hook can also be installed manually: `envault audit --install-hook`. If you move the binary after installation, re-run that command to update the embedded path.
+</Callout>
+
+### Linting env files in CI
+
+For additional enforcement in pull request checks or deployment gates, use `envault audit --format=json`. The command exits non-zero on any error, making it a clean pipeline step:
+
+```yaml
+steps:
+  - uses: actions/checkout@v3
+  - name: Install Envault CLI
+    run: curl -sL https://envault.app/install.sh | bash
+  - name: Audit env files
+    run: envault audit --strict --format=json
+```
+
+The `--strict` flag escalates warnings (orphaned keys, missing template) to errors. Omit it if you only want to block on hard errors (tracked files, missing `.gitignore` coverage).
+
 ## GitHub Actions
 
 Here is a complete workflow example for a Next.js application.

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -146,7 +146,7 @@ export async function GET(request: Request) {
                     fontFamily: "monospace",
                   }}
                 >
-                  bash — ~
+                  bash - ~
                 </span>
               </div>
             </div>


### PR DESCRIPTION
### PR Description – Close #81

This PR wraps up a multi‑facet effort to harden the CLI and polish the docs as outlined in **issue #81**.  
All changes are contained within a single merge and can be copied directly for the release.

---

####  Key enhancements

1. **Automatic pre‑commit hook installation**
   - `envault init` and `envault pull` now auto‑install the `envault audit` git hook.
   - Hook logic refactored into a shared helper; `--install-hook` flag remains for manual installs.

2. **Git‑tracked file safeguards**
   - `envault pull` and `envault deploy` perform a hard block if the target/source `.env` file is already under version control.
   - `pull` additionally auto‑appends the file to `.gitignore` when safe.
   - Helpful warnings when the repository has no `.git` directory.

3. **General CLI safety improvements**
   - New `isTrackedByGit()` and `ensureGitignoreEntry()` helpers in `cli-go/cmd/audit.go`.
   - CLI emits removable install warnings and uses the same pre‑commit binary path for reliability.

4. **Documentation overhaul**
   - Updated all relevant pages to describe the new automatic safeguards.
   - Replaced every textual emoji/arrow/cross symbol with Lucide icons for consistency.
   - Added missing imports where icons were used.
   - Performed exhaustive manual inspection of MDX files to ensure no stray symbols remain.

5. **No behavior regressions**
   - Go code compiles cleanly; existing tests unaffected.
   - Manual verification of docs shows full icon consistency.

---

This PR closes **#81** by delivering the requested integration of safety features into common commands, documenting them, and cleaning up the UX around visual symbols.  