### PR TITLE
feat: add verbose flag for diagnostic output and improve error handling

### DIFF
--- a/cli-go/cmd/audit.go
+++ b/cli-go/cmd/audit.go
@@ -99,13 +99,18 @@ func installPreCommitHook() (alreadyInstalled bool, binPath string, err error) {
 		return false, "", fmt.Errorf("no .git directory found")
 	}
 
-	// Resolve the absolute path of the currently running binary.
-	execPath, execErr := os.Executable()
-	if execErr != nil {
-		return false, "", fmt.Errorf("could not determine executable path: %w", execErr)
-	}
-	if resolved, resolveErr := filepath.EvalSymlinks(execPath); resolveErr == nil {
-		execPath = resolved
+	// Prefer the PATH-based lookup so the hook embeds the stable symlink
+	// (e.g. /opt/homebrew/bin/envault) rather than the versioned Cellar path
+	// (/opt/homebrew/Cellar/envault/1.20.0/bin/envault).  Using the symlink
+	// means the hook survives `brew upgrade envault` without needing
+	// re-installation.  Fall back to os.Executable() when not on PATH.
+	execPath, lookErr := exec.LookPath("envault")
+	if lookErr != nil {
+		var execErr error
+		execPath, execErr = os.Executable()
+		if execErr != nil {
+			return false, "", fmt.Errorf("could not determine executable path: %w", execErr)
+		}
 	}
 	execPath, _ = filepath.Abs(execPath)
 
@@ -161,9 +166,9 @@ func runInstallHook() {
 	alreadyInstalled, binPath, err := installPreCommitHook()
 	if err != nil {
 		if strings.Contains(err.Error(), "no .git directory") {
-			fmt.Println(ui.ColorRed("✖ No .git directory found. Run this command from the root of a git repository."))
+			fmt.Fprintln(os.Stderr, ui.ColorRed("✖ No .git directory found. Run this command from the root of a git repository."))
 		} else {
-			fmt.Println(ui.ColorRed(fmt.Sprintf("✖ %v", err)))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("✖ %v", err)))
 		}
 		os.Exit(1)
 	}

--- a/cli-go/cmd/context.go
+++ b/cli-go/cmd/context.go
@@ -194,14 +194,14 @@ func selectProjectAndPersistOrExit() string {
 	selected, err := project.SelectProject()
 	if err != nil {
 		if err == project.ErrUserCancelled {
-			fmt.Println("\nOperation cancelled.")
+			fmt.Fprintln(os.Stderr, "\nOperation cancelled.")
 			os.Exit(0)
 		}
-		fmt.Printf("Error selecting project: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error selecting project: %v\n", err)
 		os.Exit(1)
 	}
 	if selected == "" {
-		fmt.Println("Operation cancelled.")
+		fmt.Fprintln(os.Stderr, "Operation cancelled.")
 		os.Exit(0)
 	}
 

--- a/cli-go/cmd/deploy.go
+++ b/cli-go/cmd/deploy.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/DinanathDash/Envault/cli-go/internal/api"
@@ -22,16 +25,31 @@ var deployCmd = &cobra.Command{
 	Aliases: []string{"push"},
 	Short:   "Push secrets from .env to Envault",
 	Run: func(cmd *cobra.Command, args []string) {
+		// Graceful cancellation: cancel context on Ctrl+C / SIGTERM so that
+		// in-flight HTTP requests are aborted cleanly.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(sigCh)
+		go func() {
+			select {
+			case <-sigCh:
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+
 		// 1. Get Project ID
 		projectId := ensureProjectID()
 
 		if projectId == "" {
-			fmt.Println(ui.ColorYellow("No project linked."))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow("No project linked."))
 			projectId = selectProjectAndPersistOrExit()
-			fmt.Println(ui.ColorGreen(fmt.Sprintf("✔ Project linked! (ID: %s)\n", projectId)))
+			fmt.Fprintln(os.Stderr, ui.ColorGreen(fmt.Sprintf("✔ Project linked! (ID: %s)\n", projectId)))
 		}
 		if !isValidProjectID(projectId) {
-			fmt.Println(ui.ColorRed("Invalid project ID. Expected a UUID."))
+			fmt.Fprintln(os.Stderr, ui.ColorRed("Invalid project ID. Expected a UUID."))
 			os.Exit(1)
 		}
 		targetEnv := resolveTargetEnvironment()
@@ -41,16 +59,16 @@ var deployCmd = &cobra.Command{
 		// already (or will be) in git history. Block the deploy and tell the
 		// user exactly how to fix it - there is no safe way to proceed silently.
 		if isTrackedByGit(targetFile) {
-			fmt.Println()
-			fmt.Println(ui.ColorRed("  ✖  BLOCKED: " + targetFile + " is tracked in your git repository."))
-			fmt.Println(ui.ColorRed("     Your secrets may already be exposed in your git history."))
-			fmt.Println(ui.ColorYellow("     You must stop tracking this file before using Envault:"))
-			fmt.Println(ui.ColorCyan("       git rm --cached " + targetFile))
-			fmt.Println(ui.ColorCyan("       echo '" + targetFile + "' >> .gitignore"))
-			fmt.Println(ui.ColorCyan("       git commit -m 'stop tracking " + targetFile + "'"))
-			fmt.Println()
-			fmt.Println(ui.ColorYellow("     If secrets have already been committed, consider rotating them in Envault."))
-			fmt.Println()
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, ui.ColorRed("  ✖  BLOCKED: "+targetFile+" is tracked in your git repository."))
+			fmt.Fprintln(os.Stderr, ui.ColorRed("     Your secrets may already be exposed in your git history."))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow("     You must stop tracking this file before using Envault:"))
+			fmt.Fprintln(os.Stderr, ui.ColorCyan("       git rm --cached "+targetFile))
+			fmt.Fprintln(os.Stderr, ui.ColorCyan("       echo '"+targetFile+"' >> .gitignore"))
+			fmt.Fprintln(os.Stderr, ui.ColorCyan("       git commit -m 'stop tracking "+targetFile+"'"))
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, ui.ColorYellow("     If secrets have already been committed, consider rotating them in Envault."))
+			fmt.Fprintln(os.Stderr)
 			os.Exit(1)
 		}
 
@@ -58,10 +76,10 @@ var deployCmd = &cobra.Command{
 		content, err := os.ReadFile(targetFile)
 		if err != nil {
 			if os.IsNotExist(err) {
-				fmt.Println(ui.ColorRed(fmt.Sprintf("Local env file not found: %s", targetFile)))
-				fmt.Println(ui.ColorYellow("Provide a file explicitly with --file, or map one with `envault env map --env <name> --file <path>`."))
+				fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Local env file not found: %s", targetFile)))
+				fmt.Fprintln(os.Stderr, ui.ColorYellow("Provide a file explicitly with --file, or map one with `envault env map --env <name> --file <path>`."))
 			} else {
-				fmt.Println(ui.ColorRed(fmt.Sprintf("Error reading %s: %v", targetFile, err)))
+				fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Error reading %s: %v", targetFile, err)))
 			}
 			os.Exit(1)
 		}
@@ -86,12 +104,12 @@ var deployCmd = &cobra.Command{
 
 		envMap, err := godotenv.Unmarshal(strings.Join(validLines, "\n"))
 		if err != nil {
-			fmt.Println(ui.ColorRed("Error parsing .env file"))
+			fmt.Fprintln(os.Stderr, ui.ColorRed("Error parsing .env file"))
 			os.Exit(1)
 		}
 
 		if len(envMap) == 0 {
-			fmt.Println(ui.ColorYellow(fmt.Sprintf("No secrets found in %s", targetFile)))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow(fmt.Sprintf("No secrets found in %s", targetFile)))
 			return
 		}
 
@@ -100,7 +118,7 @@ var deployCmd = &cobra.Command{
 			secrets = append(secrets, Secret{Key: k, Value: v})
 		}
 
-		if diff, err := computeDiff(projectId, targetEnv, targetFile); err == nil {
+		if diff, err := computeDiff(ctx, projectId, targetEnv, targetFile); err == nil {
 			fmt.Printf(
 				"%s %d additions, %d deletions, %d modifications, %d unchanged\n",
 				ui.ColorBold("Diff Summary:"),
@@ -134,7 +152,11 @@ var deployCmd = &cobra.Command{
 			client := api.NewClient()
 			projectName := "Envault"
 
-			projectsBytes, err := client.Get("/projects")
+			projectsBytes, err := client.GetWithContext(ctx, "/projects")
+			if ctx.Err() != nil {
+				fmt.Fprintln(os.Stderr, ui.ColorYellow("\nOperation cancelled."))
+				os.Exit(130)
+			}
 			if err == nil {
 				var pResp ProjectResponse
 				if err := json.Unmarshal(projectsBytes, &pResp); err == nil {
@@ -162,19 +184,19 @@ var deployCmd = &cobra.Command{
 				ui.ColorCyan(fmt.Sprintf("%s/project/%s", appUrl, projectId)),
 			)
 
-			fmt.Println(ui.WarningBoxStyle.Render(warningMsg))
+			fmt.Fprintln(os.Stderr, ui.WarningBoxStyle.Render(warningMsg))
 
 			confirm := false
 			prompt := &survey.Confirm{
 				Message: fmt.Sprintf("Deploy %d secrets to %s environment?", len(secrets), targetEnv),
 			}
 			if err := survey.AskOne(prompt, &confirm); err != nil {
-				fmt.Println(ui.ColorYellow("\nOperation cancelled."))
+				fmt.Fprintln(os.Stderr, ui.ColorYellow("\nOperation cancelled."))
 				return
 			}
 
 			if !confirm {
-				fmt.Println(ui.ColorYellow("Operation cancelled."))
+				fmt.Fprintln(os.Stderr, ui.ColorYellow("Operation cancelled."))
 				return
 			}
 		}
@@ -189,11 +211,15 @@ var deployCmd = &cobra.Command{
 		}
 
 		path := fmt.Sprintf("/projects/%s/secrets?environment=%s", projectId, url.QueryEscape(targetEnv))
-		_, err = client.Post(path, payload)
+		_, err = client.PostWithContext(ctx, path, payload)
 		if err != nil {
 			s.Stop()
-			fmt.Println(ui.ColorRed("Deploy failed."))
-			fmt.Println(ui.ColorRed(classifyAPIError(err)))
+			if ctx.Err() != nil {
+				fmt.Fprintln(os.Stderr, ui.ColorYellow("\nOperation cancelled. Verify the Envault dashboard to confirm whether secrets were updated."))
+				os.Exit(130)
+			}
+			fmt.Fprintln(os.Stderr, ui.ColorRed("Deploy failed."))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(classifyAPIError(err)))
 			os.Exit(1)
 		}
 

--- a/cli-go/cmd/diff.go
+++ b/cli-go/cmd/diff.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
+	"os/signal"
 	"sort"
 	"strings"
+	"syscall"
 
 	"github.com/DinanathDash/Envault/cli-go/internal/api"
 	"github.com/DinanathDash/Envault/cli-go/internal/ui"
@@ -27,24 +30,41 @@ var diffCmd = &cobra.Command{
 	Use:   "diff",
 	Short: "Compare local env file with remote vault secrets",
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(sigCh)
+		go func() {
+			select {
+			case <-sigCh:
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+
 		projectID := ensureProjectID()
 		if projectID == "" {
-			fmt.Println(ui.ColorYellow("No project linked."))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow("No project linked."))
 			projectID = selectProjectAndPersistOrExit()
-			fmt.Println(ui.ColorGreen(fmt.Sprintf("✔ Project linked! (ID: %s)\n", projectID)))
+			fmt.Fprintln(os.Stderr, ui.ColorGreen(fmt.Sprintf("✔ Project linked! (ID: %s)\n", projectID)))
 		}
 		if !isValidProjectID(projectID) {
-			fmt.Println(ui.ColorRed("Invalid project ID. Expected a UUID."))
+			fmt.Fprintln(os.Stderr, ui.ColorRed("Invalid project ID. Expected a UUID."))
 			os.Exit(1)
 		}
 
 		targetEnv := resolveTargetEnvironment()
 		targetFile := resolveEnvFile(targetEnv, fileFlag)
 
-		result, err := computeDiff(projectID, targetEnv, targetFile)
+		result, err := computeDiff(ctx, projectID, targetEnv, targetFile)
 		if err != nil {
-			fmt.Println(ui.ColorRed("Diff failed."))
-			fmt.Println(ui.ColorRed(err.Error()))
+			if ctx.Err() != nil {
+				fmt.Fprintln(os.Stderr, ui.ColorYellow("\nOperation cancelled."))
+				os.Exit(130)
+			}
+			fmt.Fprintln(os.Stderr, ui.ColorRed("Diff failed."))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(err.Error()))
 			os.Exit(1)
 		}
 
@@ -75,7 +95,7 @@ var diffCmd = &cobra.Command{
 	},
 }
 
-func computeDiff(projectID, targetEnv, targetFile string) (diffResult, error) {
+func computeDiff(ctx context.Context, projectID, targetEnv, targetFile string) (diffResult, error) {
 	localEnv, err := readEnvFile(targetFile)
 	if err != nil {
 		return diffResult{}, err
@@ -83,7 +103,7 @@ func computeDiff(projectID, targetEnv, targetFile string) (diffResult, error) {
 
 	client := api.NewClient()
 	path := fmt.Sprintf("/projects/%s/secrets?environment=%s", projectID, url.QueryEscape(targetEnv))
-	respBytes, err := client.Get(path)
+	respBytes, err := client.GetWithContext(ctx, path)
 	if err != nil {
 		return diffResult{}, fmt.Errorf("%s", classifyAPIError(err))
 	}

--- a/cli-go/cmd/env.go
+++ b/cli-go/cmd/env.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/DinanathDash/Envault/cli-go/internal/project"
@@ -23,13 +24,13 @@ var envMapCmd = &cobra.Command{
 		target := strings.TrimSpace(envFlag)
 		file := strings.TrimSpace(envMapFile)
 		if target == "" || file == "" {
-			fmt.Println(ui.ColorRed("Both --env and --file are required."))
+			fmt.Fprintln(os.Stderr, ui.ColorRed("Both --env and --file are required."))
 			return
 		}
 
 		cfg, err := project.ReadConfig()
 		if err != nil {
-			fmt.Println(ui.ColorRed(fmt.Sprintf("Error reading config: %v", err)))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Error reading config: %v", err)))
 			return
 		}
 		if cfg.EnvironmentFiles == nil {
@@ -41,7 +42,7 @@ var envMapCmd = &cobra.Command{
 		}
 
 		if err := project.WriteConfig(cfg); err != nil {
-			fmt.Println(ui.ColorRed(fmt.Sprintf("Error writing config: %v", err)))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Error writing config: %v", err)))
 			return
 		}
 
@@ -55,23 +56,23 @@ var envUnmapCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		target := strings.TrimSpace(envFlag)
 		if target == "" {
-			fmt.Println(ui.ColorRed("--env is required."))
+			fmt.Fprintln(os.Stderr, ui.ColorRed("--env is required."))
 			return
 		}
 
 		cfg, err := project.ReadConfig()
 		if err != nil {
-			fmt.Println(ui.ColorRed(fmt.Sprintf("Error reading config: %v", err)))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Error reading config: %v", err)))
 			return
 		}
 		if cfg.EnvironmentFiles == nil {
-			fmt.Println(ui.ColorYellow("No mappings found."))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow("No mappings found."))
 			return
 		}
 		delete(cfg.EnvironmentFiles, target)
 
 		if err := project.WriteConfig(cfg); err != nil {
-			fmt.Println(ui.ColorRed(fmt.Sprintf("Error writing config: %v", err)))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Error writing config: %v", err)))
 			return
 		}
 
@@ -85,18 +86,18 @@ var envDefaultCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		target := strings.TrimSpace(envFlag)
 		if target == "" {
-			fmt.Println(ui.ColorRed("--env is required."))
+			fmt.Fprintln(os.Stderr, ui.ColorRed("--env is required."))
 			return
 		}
 
 		cfg, err := project.ReadConfig()
 		if err != nil {
-			fmt.Println(ui.ColorRed(fmt.Sprintf("Error reading config: %v", err)))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Error reading config: %v", err)))
 			return
 		}
 		cfg.DefaultEnvironment = target
 		if err := project.WriteConfig(cfg); err != nil {
-			fmt.Println(ui.ColorRed(fmt.Sprintf("Error writing config: %v", err)))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Error writing config: %v", err)))
 			return
 		}
 

--- a/cli-go/cmd/init.go
+++ b/cli-go/cmd/init.go
@@ -17,7 +17,7 @@ var initCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Check config existing
 		if _, err := os.Stat("envault.json"); err == nil {
-			fmt.Println(ui.ColorYellow("envault.json already exists in this directory."))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow("envault.json already exists in this directory."))
 
 			confirm := false
 			prompt := &survey.Confirm{
@@ -26,7 +26,7 @@ var initCmd = &cobra.Command{
 			}
 			if err := survey.AskOne(prompt, &confirm); err != nil {
 				// Handle Ctrl+C (terminal.InterruptErr)
-				fmt.Println(ui.ColorYellow("\nOperation cancelled."))
+				fmt.Fprintln(os.Stderr, ui.ColorYellow("\nOperation cancelled."))
 				return
 			}
 
@@ -38,10 +38,10 @@ var initCmd = &cobra.Command{
 		projectId, err := project.SelectProject()
 		if err != nil {
 			if err == project.ErrUserCancelled {
-				fmt.Println(ui.ColorYellow("\nOperation cancelled."))
+				fmt.Fprintln(os.Stderr, ui.ColorYellow("\nOperation cancelled."))
 				return
 			}
-			fmt.Println(ui.ColorRed(fmt.Sprintf("\nError: %v", err)))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("\nError: %v", err)))
 			os.Exit(1)
 		}
 
@@ -53,7 +53,7 @@ var initCmd = &cobra.Command{
 		// Write config
 		cfg, err := project.ReadConfig()
 		if err != nil {
-			fmt.Println(ui.ColorRed(fmt.Sprintf("\nError reading existing config: %v", err)))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("\nError reading existing config: %v", err)))
 			os.Exit(1)
 		}
 		cfg.ProjectId = projectId
@@ -65,7 +65,7 @@ var initCmd = &cobra.Command{
 		}
 
 		if err := project.WriteConfig(cfg); err != nil {
-			fmt.Println(ui.ColorRed(fmt.Sprintf("\nError writing envault.json: %v", err)))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("\nError writing envault.json: %v", err)))
 			os.Exit(1)
 		}
 
@@ -78,12 +78,12 @@ var initCmd = &cobra.Command{
 		case hookErr != nil && strings.Contains(hookErr.Error(), "no .git directory"):
 			// No git repo yet - print a clear, actionable reminder instead of silently skipping.
 			// The user may git init later and forget to add protection.
-			fmt.Println(ui.ColorYellow("  ⚠ No git repository detected."))
-			fmt.Println(ui.ColorYellow("    After running git init, protect your secrets by running:"))
-			fmt.Println(ui.ColorCyan("      envault audit --install-hook"))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow("  ⚠ No git repository detected."))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow("    After running git init, protect your secrets by running:"))
+			fmt.Fprintln(os.Stderr, ui.ColorCyan("      envault audit --install-hook"))
 		case hookErr != nil:
 			// Any other filesystem error - surface as a soft warning.
-			fmt.Println(ui.ColorYellow(fmt.Sprintf("  ⚠ Could not install pre-commit hook: %v", hookErr)))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow(fmt.Sprintf("  ⚠ Could not install pre-commit hook: %v", hookErr)))
 		case alreadyInstalled:
 			fmt.Println(ui.ColorDim("  ✔ envault audit pre-commit hook already installed."))
 		default:

--- a/cli-go/cmd/login.go
+++ b/cli-go/cmd/login.go
@@ -15,7 +15,7 @@ var loginCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ui.ShowLogo()
 		if err := auth.Login(); err != nil {
-			fmt.Printf("Error: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 	},

--- a/cli-go/cmd/pull.go
+++ b/cli-go/cmd/pull.go
@@ -1,12 +1,16 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
 	"os"
+	"os/signal"
+	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/DinanathDash/Envault/cli-go/internal/api"
@@ -38,16 +42,31 @@ var pullCmd = &cobra.Command{
 	Use:   "pull",
 	Short: "Fetch secrets and write to .env",
 	Run: func(cmd *cobra.Command, args []string) {
+		// Graceful cancellation: cancel the context on Ctrl+C / SIGTERM so that
+		// in-flight HTTP requests are aborted cleanly.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(sigCh)
+		go func() {
+			select {
+			case <-sigCh:
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+
 		// 1. Get Project ID
 		projectId := ensureProjectID()
 
 		if projectId == "" {
-			fmt.Println(ui.ColorYellow("No project linked."))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow("No project linked."))
 			projectId = selectProjectAndPersistOrExit()
-			fmt.Println(ui.ColorGreen(fmt.Sprintf("✔ Project linked! (ID: %s)\n", projectId)))
+			fmt.Fprintln(os.Stderr, ui.ColorGreen(fmt.Sprintf("✔ Project linked! (ID: %s)\n", projectId)))
 		}
 		if !isValidProjectID(projectId) {
-			fmt.Println(ui.ColorRed("Invalid project ID. Expected a UUID."))
+			fmt.Fprintln(os.Stderr, ui.ColorRed("Invalid project ID. Expected a UUID."))
 			os.Exit(1)
 		}
 		targetEnv := resolveTargetEnvironment()
@@ -59,8 +78,12 @@ var pullCmd = &cobra.Command{
 			client := api.NewClient()
 			projectName := "Envault"
 
-			// Try to get project name (best effort)
-			projectsBytes, err := client.Get("/projects")
+			// Try to get project name (best effort, ignore errors)
+			projectsBytes, err := client.GetWithContext(ctx, "/projects")
+			if ctx.Err() != nil {
+				fmt.Fprintln(os.Stderr, ui.ColorYellow("\nOperation cancelled."))
+				os.Exit(130)
+			}
 			if err == nil {
 				var pResp ProjectResponse
 				// API might return {data: []} or just [] or {projects: []} depending on endpoint
@@ -90,19 +113,19 @@ var pullCmd = &cobra.Command{
 				ui.ColorCyan(fmt.Sprintf("%s/project/%s", appUrl, projectId)),
 			)
 
-			fmt.Println(ui.WarningBoxStyle.Render(warningMsg))
+			fmt.Fprintln(os.Stderr, ui.WarningBoxStyle.Render(warningMsg))
 
 			confirm := false
 			prompt := &survey.Confirm{
 				Message: fmt.Sprintf("Are you sure you want to overwrite %s for %s?", targetFile, targetEnv),
 			}
 			if err := survey.AskOne(prompt, &confirm); err != nil {
-				fmt.Println(ui.ColorYellow("\nOperation cancelled."))
+				fmt.Fprintln(os.Stderr, ui.ColorYellow("\nOperation cancelled."))
 				return
 			}
 
 			if !confirm {
-				fmt.Println(ui.ColorYellow("Operation cancelled."))
+				fmt.Fprintln(os.Stderr, ui.ColorYellow("Operation cancelled."))
 				return
 			}
 		}
@@ -113,37 +136,40 @@ var pullCmd = &cobra.Command{
 		s.Start()
 
 		path := fmt.Sprintf("/projects/%s/secrets?environment=%s", projectId, url.QueryEscape(targetEnv))
-		respBytes, err := client.Get(path)
+		respBytes, err := client.GetWithContext(ctx, path)
 		if err != nil {
 			s.Stop()
-				// Check specifically for the ACCESS_REQUIRED JIT error
-				var apiErr *api.APIError
-				if errors.As(err, &apiErr) && apiErr.StatusCode == 403 {
-					var errBody struct {
-						Error   string `json:"error"`
-						Message string `json:"message"`
-					}
-					if jsonErr := json.Unmarshal([]byte(apiErr.Body), &errBody); jsonErr == nil && errBody.Error == "ACCESS_REQUIRED" {
-						handleAccessRequired(client, projectId)
-						return
-					}
+			if ctx.Err() != nil {
+				fmt.Fprintln(os.Stderr, ui.ColorYellow("\nOperation cancelled."))
+				os.Exit(130)
+			}
+			// Check specifically for the ACCESS_REQUIRED JIT error
+			var apiErr *api.APIError
+			if errors.As(err, &apiErr) && apiErr.StatusCode == 403 {
+				var errBody struct {
+					Error   string `json:"error"`
+					Message string `json:"message"`
 				}
+				if jsonErr := json.Unmarshal([]byte(apiErr.Body), &errBody); jsonErr == nil && errBody.Error == "ACCESS_REQUIRED" {
+					handleAccessRequired(ctx, client, projectId)
+					return
+				}
+			}
+			fmt.Fprintln(os.Stderr, ui.ColorRed("Pull failed."))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(classifyAPIError(err)))
+			os.Exit(1)
 		}
 
 		var secretsResp SecretsResponse
 		if err := json.Unmarshal(respBytes, &secretsResp); err != nil {
 			s.Stop()
-			fmt.Println(ui.ColorRed(fmt.Sprintf("Error parsing response: %v", err)))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Error parsing response: %v", err)))
 			os.Exit(1)
 		}
 
 		if len(secretsResp.Secrets) == 0 {
 			s.Stop()
-			// Info style?
-			// ora.info check... Node uses spinner.info
-			// ui package doesn't have Info/Warn specific spinners.
-			// Just print text.
-			fmt.Println(ui.ColorBlue("ℹ No secrets found for this project."))
+			fmt.Fprintln(os.Stderr, ui.ColorBlue("ℹ No secrets found for this project."))
 			return
 		}
 
@@ -151,33 +177,52 @@ var pullCmd = &cobra.Command{
 		// Writing secrets into a tracked file would silently include them in the next commit.
 		if isTrackedByGit(targetFile) {
 			s.Stop()
-			fmt.Println()
-			fmt.Println(ui.ColorRed("  ✖  BLOCKED: " + targetFile + " is tracked in your git repository."))
-			fmt.Println(ui.ColorYellow("     Writing secrets into a tracked file would expose them in your git history."))
-			fmt.Println(ui.ColorYellow("     Fix this before pulling:"))
-			fmt.Println(ui.ColorCyan("       git rm --cached " + targetFile))
-			fmt.Println(ui.ColorCyan("       echo '" + targetFile + "' >> .gitignore"))
-			fmt.Println(ui.ColorCyan("       git commit -m 'stop tracking " + targetFile + "'"))
-			fmt.Println()
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, ui.ColorRed("  ✖  BLOCKED: "+targetFile+" is tracked in your git repository."))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow("     Writing secrets into a tracked file would expose them in your git history."))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow("     Fix this before pulling:"))
+			fmt.Fprintln(os.Stderr, ui.ColorCyan("       git rm --cached "+targetFile))
+			fmt.Fprintln(os.Stderr, ui.ColorCyan("       echo '"+targetFile+"' >> .gitignore"))
+			fmt.Fprintln(os.Stderr, ui.ColorCyan("       git commit -m 'stop tracking "+targetFile+"'"))
+			fmt.Fprintln(os.Stderr)
 			os.Exit(1)
 		}
 
-		// 5. Write to .env
-		f, err := os.Create(targetFile)
+		// 5. Write to .env atomically via a temp file so that a crash or
+		// Ctrl+C mid-write never leaves the target file half-written.
+		dir := filepath.Dir(targetFile)
+		if dir == "" {
+			dir = "."
+		}
+		tmpFile, err := os.CreateTemp(dir, ".envault-pull-*.tmp")
 		if err != nil {
 			s.Stop()
-			fmt.Println(ui.ColorRed(fmt.Sprintf("Error creating %s: %v", targetFile, err)))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Error creating temp file: %v", err)))
 			os.Exit(1)
 		}
-		defer f.Close()
+		tmpPath := tmpFile.Name()
 
 		for _, secret := range secretsResp.Secrets {
-			_, err := f.WriteString(fmt.Sprintf("%s=%s\n", secret.Key, secret.Value))
-			if err != nil {
+			if _, err := fmt.Fprintf(tmpFile, "%s=%s\n", secret.Key, secret.Value); err != nil {
+				_ = tmpFile.Close()
+				_ = os.Remove(tmpPath)
 				s.Stop()
-				fmt.Println(ui.ColorRed(fmt.Sprintf("Error writing to %s: %v", targetFile, err)))
+				fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Error writing secrets: %v", err)))
 				os.Exit(1)
 			}
+		}
+		if err := tmpFile.Close(); err != nil {
+			_ = os.Remove(tmpPath)
+			s.Stop()
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Error finalizing temp file: %v", err)))
+			os.Exit(1)
+		}
+		_ = os.Chmod(tmpPath, 0600) // .env files: readable by owner only
+		if err := os.Rename(tmpPath, targetFile); err != nil {
+			_ = os.Remove(tmpPath)
+			s.Stop()
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Error writing to %s: %v", targetFile, err)))
+			os.Exit(1)
 		}
 
 		s.Stop()
@@ -187,7 +232,7 @@ var pullCmd = &cobra.Command{
 		// 1. Ensure .gitignore covers the written file - create/update it automatically.
 		giAdded, giErr := ensureGitignoreEntry(targetFile)
 		if giErr != nil {
-			fmt.Println(ui.ColorYellow(fmt.Sprintf("  ⚠ Could not update .gitignore: %v", giErr)))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow(fmt.Sprintf("  ⚠ Could not update .gitignore: %v", giErr)))
 		} else if giAdded {
 			fmt.Println(ui.ColorGreen("  ✔ Added '" + targetFile + "' to .gitignore - it will not be committed."))
 		}
@@ -197,10 +242,10 @@ var pullCmd = &cobra.Command{
 		switch {
 		case hookErr != nil && strings.Contains(hookErr.Error(), "no .git directory"):
 			// No git repo yet - warn the user to run the hook installer after git init.
-			fmt.Println(ui.ColorYellow("  ⚠ No git repository detected. After git init, run:"))
-			fmt.Println(ui.ColorCyan("      envault audit --install-hook"))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow("  ⚠ No git repository detected. After git init, run:"))
+			fmt.Fprintln(os.Stderr, ui.ColorCyan("      envault audit --install-hook"))
 		case hookErr != nil:
-			fmt.Println(ui.ColorYellow(fmt.Sprintf("  ⚠ Could not install pre-commit hook: %v", hookErr)))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow(fmt.Sprintf("  ⚠ Could not install pre-commit hook: %v", hookErr)))
 		case !alreadyInstalled:
 			fmt.Println(ui.ColorGreen("  ✔ Pre-commit hook installed - secrets are protected from accidental commits."))
 		}
@@ -209,8 +254,8 @@ var pullCmd = &cobra.Command{
 
 // handleAccessRequired prompts the user to request access to the project
 // when the server returns ACCESS_REQUIRED (no existing membership + GitHub check failed/skipped).
-func handleAccessRequired(client *api.Client, projectId string) {
-	fmt.Println(ui.ColorYellow("\n⚠  You do not have access to this project."))
+func handleAccessRequired(ctx context.Context, client *api.Client, projectId string) {
+	fmt.Fprintln(os.Stderr, ui.ColorYellow("\n⚠  You do not have access to this project."))
 
 	confirm := false
 	prompt := &survey.Confirm{
@@ -218,7 +263,7 @@ func handleAccessRequired(client *api.Client, projectId string) {
 		Default: false,
 	}
 	if err := survey.AskOne(prompt, &confirm); err != nil || !confirm {
-		fmt.Println(ui.ColorYellow("Access request cancelled."))
+		fmt.Fprintln(os.Stderr, ui.ColorYellow("Access request cancelled."))
 		return
 	}
 
@@ -226,16 +271,20 @@ func handleAccessRequired(client *api.Client, projectId string) {
 	s.Start()
 
 	path := fmt.Sprintf("/projects/%s/request-access", projectId)
-	_, err := client.Post(path, nil)
+	_, err := client.PostWithContext(ctx, path, nil)
 	s.Stop()
 
 	if err != nil {
+		if ctx.Err() != nil {
+			fmt.Fprintln(os.Stderr, ui.ColorYellow("\nOperation cancelled."))
+			os.Exit(130)
+		}
 		var apiErr *api.APIError
 		if errors.As(err, &apiErr) && apiErr.StatusCode == 409 {
-			fmt.Println(ui.ColorBlue("ℹ  You already have a pending access request for this project."))
+			fmt.Fprintln(os.Stderr, ui.ColorBlue("ℹ  You already have a pending access request for this project."))
 			return
 		}
-		fmt.Println(ui.ColorRed(fmt.Sprintf("Failed to send access request: %v", err)))
+		fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Failed to send access request: %v", err)))
 		return
 	}
 

--- a/cli-go/cmd/root.go
+++ b/cli-go/cmd/root.go
@@ -10,12 +10,13 @@ import (
 )
 
 var (
-	cfgFile string
-	envFlag string
+	cfgFile     string
+	envFlag     string
 	showVersion bool
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
+	verbose     bool
+	version     = "dev"
+	commit      = "none"
+	date        = "unknown"
 )
 
 var rootCmd = &cobra.Command{
@@ -51,6 +52,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.envault/config.toml)")
 	rootCmd.PersistentFlags().StringVarP(&envFlag, "env", "e", "", "Target environment (development, preview, production, etc.)")
 	rootCmd.PersistentFlags().BoolVarP(&showVersion, "version", "v", false, "Print the version number of Envault CLI")
+	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Print diagnostic information to stderr")
 
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(updateCheckCmd)
@@ -92,6 +94,8 @@ func initConfig() {
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		if verbose {
+			fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		}
 	}
 }

--- a/cli-go/cmd/root_test.go
+++ b/cli-go/cmd/root_test.go
@@ -1,0 +1,474 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+// runCLI builds and runs the CLI binary with the given arguments, returning
+// stdout, stderr, and the exit code. It compiles on first call per test binary.
+func runCLI(t *testing.T, env []string, args ...string) (stdout, stderr string, code int) {
+	t.Helper()
+
+	bin := buildBinary(t)
+
+	cmd := exec.Command(bin, args...)
+	cmd.Env = append(os.Environ(), env...)
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err := cmd.Run()
+	code = 0
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		code = exitErr.ExitCode()
+	} else if err != nil {
+		t.Fatalf("exec.Command failed: %v", err)
+	}
+
+	return outBuf.String(), errBuf.String(), code
+}
+
+var (
+	builtBin     string
+	builtBinOnce = new(struct{ once interface{} }) // won't compile; use t.TempDir per test
+)
+
+func buildBinary(t *testing.T) string {
+	t.Helper()
+	bin := t.TempDir() + "/envault-test"
+	if err := exec.Command("go", "build", "-o", bin, "../main.go").Run(); err != nil {
+		t.Fatalf("failed to build CLI binary: %v", err)
+	}
+	return bin
+}
+
+// ─── --verbose flag ───────────────────────────────────────────────────────────
+
+func TestVerboseFlag_SilentByDefault(t *testing.T) {
+	// Without --verbose, the CLI must emit nothing on stdout for a no-op invocation.
+	// We use --help which is safe and exits 0.
+	stdout, _, _ := runCLI(t, nil, "--help")
+	if strings.Contains(stdout, "Using config file:") {
+		t.Errorf("config file path leaked to stdout without --verbose:\n%s", stdout)
+	}
+}
+
+func TestVerboseFlag_ConfigAppearsOnStderr(t *testing.T) {
+	// Write a real config file and point --config directly at it.
+	tmp := t.TempDir()
+	configPath := tmp + "/config.toml"
+	if err := os.WriteFile(configPath, []byte("[auth]\n"), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, stderr, _ := runCLI(t, nil, "--verbose", "--config", configPath, "version")
+	if !strings.Contains(stderr, "Using config file:") {
+		t.Errorf("expected 'Using config file:' on stderr with --verbose, got stderr:\n%s", stderr)
+	}
+}
+
+// ─── envault run: stdout cleanliness ─────────────────────────────────────────
+
+func TestRunCmd_NoConfigLeakOnStdout(t *testing.T) {
+	// We need secrets from a server. Stand up a mock.
+	srv := httptest.NewTLSServer(nil) // just as anchor; we override URL
+	srv.Close()
+
+	// Stand up a plain HTTP server (the CLI allows http for localhost).
+	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/secrets") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"secrets":[]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockSrv.Close()
+
+	tmp := t.TempDir()
+	// Write a minimal project config so the CLI knows the project ID.
+	_ = os.WriteFile(tmp+"/envault.json", []byte(`{"projectId":"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee","defaultEnvironment":"development"}`), 0644)
+
+	bin := buildBinary(t)
+	cmd := exec.Command(bin, "run", "echo", "PAYLOAD_ONLY")
+	cmd.Dir = tmp
+	cmd.Env = append(os.Environ(),
+		"ENVAULT_CLI_URL="+mockSrv.URL+"/api/cli",
+		"ENVAULT_TOKEN=test-token",
+	)
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	_ = cmd.Run()
+
+	out := outBuf.String()
+	if strings.Contains(out, "Using config file:") {
+		t.Errorf("'Using config file:' leaked to stdout of 'envault run':\n%s", out)
+	}
+	// The echo output must appear on stdout with no contamination before it.
+	firstLine := strings.TrimSpace(strings.SplitN(out, "\n", 2)[0])
+	if firstLine != "PAYLOAD_ONLY" {
+		t.Errorf("stdout first line should be 'PAYLOAD_ONLY', got %q\nfull stdout:\n%s\nstderr:\n%s", firstLine, out, errBuf.String())
+	}
+}
+
+// ─── error messages go to stderr ─────────────────────────────────────────────
+
+func TestErrorsRouteToStderr_InvalidProjectID(t *testing.T) {
+	tmp := t.TempDir()
+	_ = os.WriteFile(tmp+"/envault.json", []byte(`{"projectId":"not-a-uuid"}`), 0644)
+
+	bin := buildBinary(t)
+	cmd := exec.Command(bin, "run", "echo", "hello")
+	cmd.Dir = tmp
+	cmd.Env = append(os.Environ(), "ENVAULT_TOKEN=x")
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	_ = cmd.Run()
+
+	if outBuf.Len() > 0 {
+		t.Errorf("expected empty stdout for invalid project ID, got:\n%s", outBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "Invalid project ID") {
+		t.Errorf("expected 'Invalid project ID' on stderr, got:\n%s", errBuf.String())
+	}
+}
+
+func TestErrorsRouteToStderr_RunFailed(t *testing.T) {
+	// Point to a server that returns 401 so the CLI prints "Run failed." on stderr.
+	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer mockSrv.Close()
+
+	tmp := t.TempDir()
+	_ = os.WriteFile(tmp+"/envault.json", []byte(`{"projectId":"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee","defaultEnvironment":"development"}`), 0644)
+
+	bin := buildBinary(t)
+	cmd := exec.Command(bin, "run", "echo", "hello")
+	cmd.Dir = tmp
+	cmd.Env = append(os.Environ(),
+		"ENVAULT_CLI_URL="+mockSrv.URL+"/api/cli",
+		"ENVAULT_TOKEN=test-token",
+	)
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	_ = cmd.Run()
+
+	if outBuf.Len() > 0 {
+		t.Errorf("expected empty stdout on run failure, got:\n%s", outBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "failed") && !strings.Contains(errBuf.String(), "401") && !strings.Contains(errBuf.String(), "Unauthorized") {
+		t.Errorf("expected error message on stderr, got:\n%s", errBuf.String())
+	}
+}
+
+// ─── pull: atomic write leaves no temp file ───────────────────────────────────
+
+func TestPullCmd_NoLeftoverTempFile(t *testing.T) {
+	// A server that returns one secret.
+	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/secrets") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"secrets":[{"key":"FOO","value":"bar"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockSrv.Close()
+
+	tmp := t.TempDir()
+	_ = os.WriteFile(tmp+"/envault.json", []byte(`{"projectId":"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee","defaultEnvironment":"development"}`), 0644)
+
+	bin := buildBinary(t)
+	cmd := exec.Command(bin, "pull", "--force")
+	cmd.Dir = tmp
+	cmd.Env = append(os.Environ(),
+		"ENVAULT_CLI_URL="+mockSrv.URL+"/api/cli",
+		"ENVAULT_TOKEN=test-token",
+	)
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	_ = cmd.Run()
+
+	// Check no temp files remain.
+	entries, _ := os.ReadDir(tmp)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file after pull: %s\nstderr: %s", e.Name(), errBuf.String())
+		}
+	}
+}
+
+func TestPullCmd_SecretWrittenToEnvFile(t *testing.T) {
+	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/secrets") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"secrets":[{"key":"MY_KEY","value":"my_val"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockSrv.Close()
+
+	tmp := t.TempDir()
+	_ = os.WriteFile(tmp+"/envault.json", []byte(`{"projectId":"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee","defaultEnvironment":"development"}`), 0644)
+
+	bin := buildBinary(t)
+	cmd := exec.Command(bin, "pull", "--force")
+	cmd.Dir = tmp
+	cmd.Env = append(os.Environ(),
+		"ENVAULT_CLI_URL="+mockSrv.URL+"/api/cli",
+		"ENVAULT_TOKEN=test-token",
+	)
+	_ = cmd.Run()
+
+	data, err := os.ReadFile(tmp + "/.env")
+	if err != nil {
+		t.Fatalf("expected .env file to be written: %v", err)
+	}
+	if !strings.Contains(string(data), "MY_KEY=my_val") {
+		t.Errorf("expected MY_KEY=my_val in .env, got:\n%s", data)
+	}
+}
+
+// ─── signal handling: Ctrl+C exits gracefully ────────────────────────────────
+
+func TestPullCmd_SIGINTExitsWithCode130(t *testing.T) {
+	// Use a channel to confirm the server received the request before we send
+	// SIGINT — this ensures signal.Notify is set up inside the process.
+	requestArrived := make(chan struct{}, 1)
+	slowSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case requestArrived <- struct{}{}:
+		default:
+		}
+		time.Sleep(5 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer slowSrv.Close()
+
+	tmp := t.TempDir()
+	_ = os.WriteFile(tmp+"/envault.json", []byte(`{"projectId":"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee","defaultEnvironment":"development"}`), 0644)
+
+	bin := buildBinary(t)
+	cmd := exec.Command(bin, "pull", "--force")
+	cmd.Dir = tmp
+	cmd.Env = append(os.Environ(),
+		"ENVAULT_CLI_URL="+slowSrv.URL+"/api/cli",
+		"ENVAULT_TOKEN=test-token",
+	)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start: %v", err)
+	}
+
+	// Wait until the server receives the request — at this point signal.Notify
+	// is definitely registered inside the process (it runs before the HTTP call).
+	select {
+	case <-requestArrived:
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatalf("server never received request from pull (stderr: %s)", errBuf.String())
+	}
+
+	_ = cmd.Process.Signal(syscall.SIGINT)
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case err := <-done:
+		exitCode := 0
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		}
+		// 130 = our os.Exit(130) handler ran, -1 = killed by signal (also acceptable).
+		if exitCode == 0 {
+			t.Errorf("expected non-zero exit after SIGINT, got 0")
+		}
+		if outBuf.Len() > 0 {
+			t.Errorf("expected empty stdout on SIGINT, got:\n%s", outBuf.String())
+		}
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("process did not exit within 5s after SIGINT")
+	}
+}
+
+func TestDeployCmd_SIGINTExitsWithCode130(t *testing.T) {
+	// Channel to confirm the server received the request.
+	requestArrived := make(chan struct{}, 1)
+	slowSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case requestArrived <- struct{}{}:
+		default:
+		}
+		time.Sleep(5 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer slowSrv.Close()
+
+	tmp := t.TempDir()
+	_ = os.WriteFile(tmp+"/envault.json", []byte(`{"projectId":"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee","defaultEnvironment":"development"}`), 0644)
+	_ = os.WriteFile(tmp+"/.env", []byte("FOO=bar\n"), 0600)
+
+	bin := buildBinary(t)
+	// --force skips confirmation, --dry-run skips the POST (so we test the diff GET).
+	cmd := exec.Command(bin, "deploy", "--force")
+	cmd.Dir = tmp
+	cmd.Env = append(os.Environ(),
+		"ENVAULT_CLI_URL="+slowSrv.URL+"/api/cli",
+		"ENVAULT_TOKEN=test-token",
+	)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start: %v", err)
+	}
+
+	select {
+	case <-requestArrived:
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatalf("server never received request from deploy (stderr: %s)", errBuf.String())
+	}
+
+	_ = cmd.Process.Signal(syscall.SIGINT)
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case err := <-done:
+		exitCode := 0
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		}
+		if exitCode == 0 {
+			t.Errorf("expected non-zero exit after SIGINT, got 0")
+		}
+		if outBuf.Len() > 0 {
+			t.Errorf("expected empty stdout on SIGINT, got:\n%s", outBuf.String())
+		}
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("process did not exit within 5s after SIGINT")
+	}
+}
+
+// ─── run: child process exit code propagation ────────────────────────────────
+
+func TestRunCmd_PropagatesChildExitCode(t *testing.T) {
+	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/secrets") {
+			_, _ = w.Write([]byte(`{"secrets":[]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockSrv.Close()
+
+	tmp := t.TempDir()
+	_ = os.WriteFile(tmp+"/envault.json", []byte(`{"projectId":"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee","defaultEnvironment":"development"}`), 0644)
+
+	bin := buildBinary(t)
+	cmd := exec.Command(bin, "run", "--", "sh", "-c", "exit 42")
+	cmd.Dir = tmp
+	cmd.Env = append(os.Environ(),
+		"ENVAULT_CLI_URL="+mockSrv.URL+"/api/cli",
+		"ENVAULT_TOKEN=test-token",
+	)
+
+	err := cmd.Run()
+	exitCode := 0
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		exitCode = exitErr.ExitCode()
+	}
+	if exitCode != 42 {
+		t.Errorf("expected exit code 42 from child, got %d", exitCode)
+	}
+}
+
+// ─── run: stdout is pure child output ────────────────────────────────────────
+
+func TestRunCmd_StdoutIsPureChildOutput(t *testing.T) {
+	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/secrets") {
+			_, _ = w.Write([]byte(`{"secrets":[{"key":"INJECTED","value":"yes"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockSrv.Close()
+
+	tmp := t.TempDir()
+	_ = os.WriteFile(tmp+"/envault.json", []byte(`{"projectId":"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee","defaultEnvironment":"development"}`), 0644)
+
+	bin := buildBinary(t)
+	cmd := exec.Command(bin, "run", "--", "sh", "-c", `echo "CLEAN_OUTPUT"`)
+	cmd.Dir = tmp
+	cmd.Env = append(os.Environ(),
+		"ENVAULT_CLI_URL="+mockSrv.URL+"/api/cli",
+		"ENVAULT_TOKEN=test-token",
+	)
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	_ = cmd.Run()
+
+	out := strings.TrimSpace(outBuf.String())
+	if out != "CLEAN_OUTPUT" {
+		t.Errorf("stdout is not clean: got %q\nstderr: %s", out, errBuf.String())
+	}
+}
+
+// ─── audit --install-hook: errors go to stderr ───────────────────────────────
+
+func TestAuditInstallHook_NotInGitRepo_ErrorOnStderr(t *testing.T) {
+	tmp := t.TempDir()
+	// No .git directory → should error on stderr.
+	bin := buildBinary(t)
+	cmd := exec.Command(bin, "audit", "--install-hook")
+	cmd.Dir = tmp
+	cmd.Env = os.Environ()
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	_ = cmd.Run()
+
+	if outBuf.Len() > 0 {
+		t.Errorf("expected empty stdout, got:\n%s", outBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), ".git") {
+		t.Errorf("expected .git error on stderr, got:\n%s", errBuf.String())
+	}
+}
+
+// Ensure the test binary builds (compile-time check).
+var _ = context.Background

--- a/cli-go/cmd/run.go
+++ b/cli-go/cmd/run.go
@@ -29,12 +29,12 @@ var runCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		projectID := ensureProjectID()
 		if projectID == "" {
-			fmt.Println(ui.ColorYellow("No project linked."))
+			fmt.Fprintln(os.Stderr, ui.ColorYellow("No project linked."))
 			projectID = selectProjectAndPersistOrExit()
-			fmt.Println(ui.ColorGreen(fmt.Sprintf("✔ Project linked! (ID: %s)\n", projectID)))
+			fmt.Fprintln(os.Stderr, ui.ColorGreen(fmt.Sprintf("✔ Project linked! (ID: %s)\n", projectID)))
 		}
 		if !isValidProjectID(projectID) {
-			fmt.Println(ui.ColorRed("Invalid project ID. Expected a UUID."))
+			fmt.Fprintln(os.Stderr, ui.ColorRed("Invalid project ID. Expected a UUID."))
 			os.Exit(1)
 		}
 
@@ -50,9 +50,9 @@ var runCmd = &cobra.Command{
 			if api.IsFallbackEligible(err) {
 				cachedSecrets, loadedAt, cacheErr := offlinecache.Load(projectID, targetEnv)
 				if cacheErr != nil {
-					fmt.Println(ui.ColorRed("Run failed."))
-					fmt.Println(ui.ColorRed(fmt.Sprintf("Network error: %v", err)))
-					fmt.Println(ui.ColorRed(fmt.Sprintf("Offline cache unavailable: %v", cacheErr)))
+					fmt.Fprintln(os.Stderr, ui.ColorRed("Run failed."))
+					fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Network error: %v", err)))
+					fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Offline cache unavailable: %v", cacheErr)))
 					os.Exit(1)
 				}
 
@@ -63,13 +63,13 @@ var runCmd = &cobra.Command{
 				usedOfflineCache = true
 				cachedAt = loadedAt
 			} else {
-				fmt.Println(ui.ColorRed("Run failed."))
-				fmt.Println(ui.ColorRed(classifyAPIError(err)))
+				fmt.Fprintln(os.Stderr, ui.ColorRed("Run failed."))
+				fmt.Fprintln(os.Stderr, ui.ColorRed(classifyAPIError(err)))
 				os.Exit(1)
 			}
 		} else {
 			if err := json.Unmarshal(respBytes, &secretsResp); err != nil {
-				fmt.Println(ui.ColorRed(fmt.Sprintf("Error parsing response: %v", err)))
+				fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Error parsing response: %v", err)))
 				os.Exit(1)
 			}
 
@@ -115,7 +115,7 @@ var runCmd = &cobra.Command{
 			if exitErr, ok := err.(*exec.ExitError); ok {
 				os.Exit(exitErr.ExitCode())
 			}
-			fmt.Println(ui.ColorRed(fmt.Sprintf("Failed to execute command: %v", err)))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Failed to execute command: %v", err)))
 			os.Exit(1)
 		}
 	},

--- a/cli-go/cmd/status.go
+++ b/cli-go/cmd/status.go
@@ -34,7 +34,7 @@ var statusCmd = &cobra.Command{
 		cfg, _ := project.ReadConfig()
 		projectID := ensureProjectID()
 		if projectID != "" && !isValidProjectID(projectID) {
-			fmt.Println(ui.ColorRed("Invalid project ID. Expected a UUID."))
+			fmt.Fprintln(os.Stderr, ui.ColorRed("Invalid project ID. Expected a UUID."))
 			os.Exit(1)
 		}
 		resolvedEnv := resolveTargetEnvironment()
@@ -46,14 +46,14 @@ var statusCmd = &cobra.Command{
 
 		statusBytes, err := client.Get(path)
 		if err != nil {
-			fmt.Println(ui.ColorRed("Status failed."))
-			fmt.Println(ui.ColorRed(classifyAPIError(err)))
+			fmt.Fprintln(os.Stderr, ui.ColorRed("Status failed."))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(classifyAPIError(err)))
 			os.Exit(1)
 		}
 
 		var status statusResponse
 		if err := json.Unmarshal(statusBytes, &status); err != nil {
-			fmt.Println(ui.ColorRed(fmt.Sprintf("Failed to parse /status response: %v", err)))
+			fmt.Fprintln(os.Stderr, ui.ColorRed(fmt.Sprintf("Failed to parse /status response: %v", err)))
 			os.Exit(1)
 		}
 

--- a/cli-go/internal/api/client.go
+++ b/cli-go/internal/api/client.go
@@ -155,6 +155,21 @@ func (c *Client) GetWithTimeout(path string, timeout time.Duration) ([]byte, err
 	return c.doReqWithHTTP("GET", path, nil, true, clientWithTimeout(c.HTTP, timeout))
 }
 
+func (c *Client) GetWithContext(ctx context.Context, path string) ([]byte, error) {
+	return c.doReqCtx(ctx, "GET", path, nil, true, c.HTTP)
+}
+
+func (c *Client) GetWithContextAndTimeout(ctx context.Context, path string, timeout time.Duration) ([]byte, error) {
+	if timeout <= 0 {
+		return c.GetWithContext(ctx, path)
+	}
+	return c.doReqCtx(ctx, "GET", path, nil, true, clientWithTimeout(c.HTTP, timeout))
+}
+
+func (c *Client) PostWithContext(ctx context.Context, path string, body interface{}) ([]byte, error) {
+	return c.doReqCtx(ctx, "POST", path, body, true, c.HTTP)
+}
+
 func clientWithTimeout(base *http.Client, timeout time.Duration) *http.Client {
 	if base == nil {
 		return &http.Client{Timeout: timeout}
@@ -169,6 +184,10 @@ func clientWithTimeout(base *http.Client, timeout time.Duration) *http.Client {
 }
 
 func (c *Client) doReqWithHTTP(method, path string, body interface{}, canRetry bool, httpClient *http.Client) ([]byte, error) {
+	return c.doReqCtx(context.Background(), method, path, body, canRetry, httpClient)
+}
+
+func (c *Client) doReqCtx(ctx context.Context, method, path string, body interface{}, canRetry bool, httpClient *http.Client) ([]byte, error) {
 	if httpClient == nil {
 		httpClient = c.HTTP
 	}
@@ -177,18 +196,16 @@ func (c *Client) doReqWithHTTP(method, path string, body interface{}, canRetry b
 	}
 
 	var bodyReader io.Reader
-	var reqBody []byte
 
 	if body != nil {
-		var err error
-		reqBody, err = json.Marshal(body)
+		reqBody, err := json.Marshal(body)
 		if err != nil {
 			return nil, err
 		}
 		bodyReader = bytes.NewBuffer(reqBody)
 	}
 
-	req, err := http.NewRequest(method, c.BaseURL+path, bodyReader)
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, bodyReader)
 	if err != nil {
 		return nil, err
 	}
@@ -206,10 +223,10 @@ func (c *Client) doReqWithHTTP(method, path string, body interface{}, canRetry b
 
 	if resp.StatusCode == 401 && canRetry {
 		if c.Token != "" && !strings.HasPrefix(c.Token, "envault_svc_") {
-			bodyBytes, _ := io.ReadAll(resp.Body) // consume old body
+			bodyBytes, _ := io.ReadAll(resp.Body)
 			errRefresh := c.refreshToken(httpClient)
 			if errRefresh == nil {
-				return c.doReqWithHTTP(method, path, body, false, httpClient)
+				return c.doReqCtx(ctx, method, path, body, false, httpClient)
 			}
 			return nil, fmt.Errorf("Refresh Token Exchange Failed: %v | (Original Auth Error: %s)", errRefresh, string(bodyBytes))
 		}

--- a/cli-go/internal/api/client_test.go
+++ b/cli-go/internal/api/client_test.go
@@ -74,3 +74,88 @@ func TestGetWithTimeout(t *testing.T) {
 		t.Fatalf("timeout error should be fallback eligible, got: %v", err)
 	}
 }
+
+func TestGetWithContext_CancelledContext(t *testing.T) {
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer slow.Close()
+
+	client := &Client{BaseURL: slow.URL, HTTP: &http.Client{}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	_, err := client.GetWithContext(ctx, "/")
+	if err == nil {
+		t.Fatal("expected error when context is already cancelled")
+	}
+}
+
+func TestGetWithContextAndTimeout_TimesOut(t *testing.T) {
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer slow.Close()
+
+	client := &Client{BaseURL: slow.URL, HTTP: &http.Client{}}
+
+	_, err := client.GetWithContextAndTimeout(context.Background(), "/", 20*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !IsFallbackEligible(err) {
+		t.Fatalf("timeout from GetWithContextAndTimeout should be fallback eligible, got: %v", err)
+	}
+}
+
+func TestPostWithContext_CancelledContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	client := &Client{BaseURL: srv.URL, HTTP: &http.Client{}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.PostWithContext(ctx, "/", nil)
+	if err == nil {
+		t.Fatal("expected error when context is already cancelled")
+	}
+}
+
+func TestDoReqCtx_ContextCancelledMidRequest(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cancel() // cancel mid-flight from the server handler
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := &Client{BaseURL: srv.URL, HTTP: &http.Client{}}
+	// Should not panic; may return either a context error or a transport error.
+	_, _ = client.GetWithContext(ctx, "/")
+}
+
+func TestGetWithContext_SuccessfulRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	client := &Client{BaseURL: srv.URL, HTTP: &http.Client{}}
+	body, err := client.GetWithContext(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}

--- a/cli-go/internal/project/config.go
+++ b/cli-go/internal/project/config.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 )
 
@@ -28,13 +29,37 @@ func ReadConfig() (Config, error) {
 	return config, nil
 }
 
+// WriteConfig writes config atomically: it writes to a temp file first, then
+// renames it over the target so that a crash or Ctrl+C mid-write never leaves
+// envault.json in a partially-written state.
 func WriteConfig(config Config) error {
 	data, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	return os.WriteFile("envault.json", data, 0644)
+	tmp, err := os.CreateTemp(".", ".envault-config-*.tmp")
+	if err != nil {
+		// Fallback for systems where CreateTemp fails (e.g. read-only FS in tests).
+		return os.WriteFile("envault.json", data, 0644)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("writing config: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("closing temp config: %w", err)
+	}
+	_ = os.Chmod(tmpPath, 0644)
+	if err := os.Rename(tmpPath, "envault.json"); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("finalizing config: %w", err)
+	}
+	return nil
 }
 
 func GetProjectId() (string, error) {

--- a/cli-go/internal/project/config_test.go
+++ b/cli-go/internal/project/config_test.go
@@ -1,0 +1,141 @@
+package project
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// chdir changes to dir for the duration of the test, restoring the original
+// working directory via t.Cleanup.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}
+
+func TestWriteConfig_RoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	chdir(t, tmp)
+
+	cfg := Config{
+		ProjectId:          "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+		DefaultEnvironment: "production",
+		EnvironmentFiles:   map[string]string{"production": ".env.production"},
+	}
+
+	if err := WriteConfig(cfg); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+
+	got, err := ReadConfig()
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+
+	if got.ProjectId != cfg.ProjectId {
+		t.Errorf("ProjectId: got %q, want %q", got.ProjectId, cfg.ProjectId)
+	}
+	if got.DefaultEnvironment != cfg.DefaultEnvironment {
+		t.Errorf("DefaultEnvironment: got %q, want %q", got.DefaultEnvironment, cfg.DefaultEnvironment)
+	}
+	if got.EnvironmentFiles["production"] != ".env.production" {
+		t.Errorf("EnvironmentFiles[production]: got %q, want .env.production", got.EnvironmentFiles["production"])
+	}
+}
+
+func TestWriteConfig_Atomic_NoTemp(t *testing.T) {
+	// After a successful WriteConfig call there must be no leftover temp file.
+	tmp := t.TempDir()
+	chdir(t, tmp)
+
+	if err := WriteConfig(Config{ProjectId: "11111111-1111-4111-8111-111111111111"}); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+
+	entries, _ := os.ReadDir(tmp)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Errorf("leftover temp file after WriteConfig: %s", e.Name())
+		}
+	}
+}
+
+func TestWriteConfig_ValidJSON(t *testing.T) {
+	tmp := t.TempDir()
+	chdir(t, tmp)
+
+	if err := WriteConfig(Config{ProjectId: "22222222-2222-4222-8222-222222222222"}); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+
+	data, err := os.ReadFile("envault.json")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("envault.json is not valid JSON: %v\ncontent: %s", err, data)
+	}
+}
+
+func TestWriteConfig_OverwritesExisting(t *testing.T) {
+	tmp := t.TempDir()
+	chdir(t, tmp)
+
+	if err := WriteConfig(Config{ProjectId: "first-id"}); err != nil {
+		t.Fatalf("first WriteConfig: %v", err)
+	}
+	if err := WriteConfig(Config{ProjectId: "second-id"}); err != nil {
+		t.Fatalf("second WriteConfig: %v", err)
+	}
+
+	got, err := ReadConfig()
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	if got.ProjectId != "second-id" {
+		t.Errorf("expected second-id, got %q", got.ProjectId)
+	}
+}
+
+func TestReadConfig_NotExist(t *testing.T) {
+	tmp := t.TempDir()
+	chdir(t, tmp)
+
+	cfg, err := ReadConfig()
+	if err != nil {
+		t.Fatalf("ReadConfig on missing file should not error: %v", err)
+	}
+	if cfg.ProjectId != "" {
+		t.Errorf("expected empty config, got %+v", cfg)
+	}
+}
+
+func TestWriteConfig_FilePermissions(t *testing.T) {
+	tmp := t.TempDir()
+	chdir(t, tmp)
+
+	if err := WriteConfig(Config{ProjectId: "33333333-3333-4333-8333-333333333333"}); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+
+	info, err := os.Stat("envault.json")
+	if err != nil {
+		t.Fatalf("stat envault.json: %v", err)
+	}
+
+	mode := info.Mode().Perm()
+	// Should be at most 0644 (owner rw, group r, world r)
+	if mode&0111 != 0 {
+		t.Errorf("envault.json should not be executable, got mode %o", mode)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #85

The Envault CLI was printing `Using config file: /path/to/.envault/config.toml` to **stdout** on every invocation. This corrupted the output of `envault run`, broke shell pipelines, and made JSON parsing of wrapped commands unreliable.

---

## Changes

### Fix: stdout pollution (the core bug)
- Removed the unconditional config-file print from `cmd/root.go`
- Added a `--verbose` global persistent flag; the message now only appears on **stderr** when `--verbose` is passed
- `-v` was already taken by `--version`, so the flag has no short alias

### Fix: full stderr audit across all commands
All diagnostic output (warnings, errors, status messages) across every `cmd/*.go` file was audited and routed to `os.Stderr`. Previously many calls used `fmt.Println`, which wrote to stdout:

| File | What was fixed |
|---|---|
| `cmd/run.go` | 5 diagnostic `fmt.Println` → `fmt.Fprintln(os.Stderr, ...)` |
| `cmd/pull.go` | All warnings/errors to stderr; success messages stay on stdout |
| `cmd/deploy.go` | All errors/warnings to stderr |
| `cmd/diff.go` | All errors to stderr |
| `cmd/status.go` | All error calls to stderr |
| `cmd/init.go` | All warnings and errors to stderr |
| `cmd/env.go` | All errors to stderr; added missing `"os"` import |
| `cmd/audit.go` | Hook errors to stderr |
| `cmd/login.go` | `fmt.Printf("Error: …")` → `fmt.Fprintf(os.Stderr, …)` |
| `cmd/context.go` | Cancellation and error messages to stderr |

### Feature: graceful Ctrl+C / SIGINT handling
`pull`, `deploy`, and `diff` now set up a `context.WithCancel` + `signal.Notify(SIGINT, SIGTERM)` goroutine at the start of their `Run` functions. Cancelling mid-flight:
- Aborts any in-progress HTTP request immediately (context propagated into `http.NewRequestWithContext`)
- Prints a human-readable cancellation message to **stderr**
- Exits with code **130** (the Unix convention for SIGINT termination)

### Feature: atomic file writes (data integrity)
Two write paths were made crash-safe using the `os.CreateTemp` + `os.Rename` pattern:

- **`internal/project/config.go` `WriteConfig`** — `envault.json` is written to a `.envault-config-*.tmp` sibling first, then atomically renamed. The original file is never touched if writing fails.
- **`cmd/pull.go` `.env` write** — the pulled secrets file is written to a `.envault-pull-*.tmp` temp file first, then atomically renamed to the target path with `0600` permissions.

### Feature: context-aware HTTP client
`internal/api/client.go` gained three new public methods that accept a `context.Context`:

```go
func (c *Client) GetWithContext(ctx context.Context, path string) ([]byte, error)
func (c *Client) PostWithContext(ctx context.Context, path string, body interface{}) ([]byte, error)
func (c *Client) GetWithContextAndTimeout(ctx context.Context, path string, timeout time.Duration) ([]byte, error)