### PR TITLE
fix(ui): load orb planet animation on device auth and approve request pages

### DIFF
--- a/src/components/landing/GlobalScene.tsx
+++ b/src/components/landing/GlobalScene.tsx
@@ -23,7 +23,10 @@ export function GlobalScene() {
   }, []);
 
   const isAuthPage =
-    pathname?.startsWith("/login") || pathname?.startsWith("/register");
+    pathname?.startsWith("/login") ||
+    pathname?.startsWith("/register") ||
+    pathname?.startsWith("/auth/device") ||
+    pathname?.startsWith("/approve");
   const isLandingPage = pathname === "/";
 
   useEffect(() => {


### PR DESCRIPTION
## Description
This PR addresses an issue where the 3D orb planet animation was failing to load on the "Device Authentication" (`/auth/device`) and "Approve Request" (`/approve/[requestId]`) pages.

- closes #97 

### Changes Made
- Updated the `isAuthPage` check in [src/components/landing/GlobalScene.tsx](cci:7://file:///d:/ED/Envault/src/components/landing/GlobalScene.tsx:0:0-0:0) to include the `/auth/device` and `/approve` paths.

### Root Cause
Previously, [GlobalScene.tsx](cci:7://file:///d:/ED/Envault/src/components/landing/GlobalScene.tsx:0:0-0:0) conditionally rendered the 3D scene by checking if `pathname` started with `/login` or `/register`. Because the device auth and approve request pages didn't match those conditions, the component was rendering `null`, resulting in an empty space where the animation should have been. 

### Testing
- Navigated to `/auth/device` and confirmed the 3D scene renders correctly.
- Navigated to a sample `/approve/[requestId]` route and verified the animation is present.