### PR TITLE
fix(ci): install conventional commits preset for semantic-release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install semantic-release dependencies
         run: |
-          npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/npm @semantic-release/git @semantic-release/exec
+          npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/npm @semantic-release/git @semantic-release/exec conventional-changelog-conventionalcommits
 
       - name: Ensure CLI changes exist since last tag
         id: cli_scope


### PR DESCRIPTION
Summary: add missing conventional-changelog-conventionalcommits dependency in publish workflow. Why: commit-analyzer uses preset conventionalcommits and fails with MODULE_NOT_FOUND without that package.