### PR TITLE
chore(app-release): bump app version to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ All notable changes to Envault are documented here.
 
 ---
 
+## 1.3.1 — 2026-03-14
+
+> Authors: Dinanath Dash (DinanathDash), Rajat Patra (RawJat)
+
+### Improvements
+
+- **CLI Release Workflow Reliability:** Updated publish workflow gating to release when CLI files changed since the last CLI tag, even if app/docs commits also exist in the repo history.
+- **Semantic-Release Stability:** Added the missing `conventional-changelog-conventionalcommits` dependency required by `@semantic-release/commit-analyzer` preset loading.
+- **NPM Publish Metadata Cleanup:** Fixed CLI wrapper package metadata to remove npm publish auto-corrections (`bin` path normalization and repository URL format).
+- **GoReleaser Modernization:** Migrated deprecated archive/homebrew keys and refined changelog filtering to reduce noise and exclude release-loop commit messages.
+- **Routine Dependency Refresh:** Applied a safe semver-range dependency update pass and regenerated lockfile state.
+
+---
+
 ## 1.3.0 — 2026-03-14
 
 > Authors: Dinanath Dash (DinanathDash), Rajat Patra (RawJat)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "envault",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "envault",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "envault",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Summary: add a small 1.3.1 changelog entry for recent CLI release workflow/package reliability fixes and bump app version metadata files.

Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>