### PR TITLE
fix: preserve identity and activity across account/member lifecycle

### DIFF
--- a/src/app/[handle]/[slug]/page.tsx
+++ b/src/app/[handle]/[slug]/page.tsx
@@ -179,7 +179,8 @@ export default async function SharedProjectPage({
   }
 
   const hasActiveEnvironmentAccess =
-    !allowedEnvironments || allowedEnvironments.includes(activeEnvironment.slug);
+    !allowedEnvironments ||
+    allowedEnvironments.includes(activeEnvironment.slug);
 
   // Fetch secrets + sharedSecrets in parallel (both need project.id)
   const [
@@ -331,7 +332,8 @@ export default async function SharedProjectPage({
       slug: env.slug,
       name: env.name,
       is_default: env.is_default,
-      can_access: !allowedEnvironments || allowedEnvironments.includes(env.slug),
+      can_access:
+        !allowedEnvironments || allowedEnvironments.includes(env.slug),
     })),
     owner_username: handle,
     createdAt: project.created_at,
@@ -346,6 +348,18 @@ export default async function SharedProjectPage({
             console.error(`Failed to decrypt key: ${secret.key}`, error);
           }
         }
+
+        const creatorFromMap = secret.user_id
+          ? userMap.get(secret.user_id)
+          : undefined;
+        const updaterFromMap = secret.last_updated_by
+          ? userMap.get(secret.last_updated_by)
+          : undefined;
+        const updaterSnapshotId =
+          (secret.last_updated_by_user_id_snapshot as string | undefined) ||
+          secret.last_updated_by ||
+          undefined;
+
         return {
           id: secret.id,
           key: secret.key,
@@ -355,10 +369,39 @@ export default async function SharedProjectPage({
           isShared: secret.isShared || false,
           sharedAt: secret.sharedAt,
           userInfo: {
-            creator: secret.user_id ? userMap.get(secret.user_id) : undefined,
-            updater: secret.last_updated_by
-              ? userMap.get(secret.last_updated_by)
+            creator: secret.user_id
+              ? secret.created_by_name || secret.created_by_email
+                ? {
+                    id:
+                      (secret.created_by_user_id_snapshot as
+                        | string
+                        | undefined) || secret.user_id,
+                    email:
+                      (secret.created_by_email as string | undefined) || "",
+                    username:
+                      (secret.created_by_name as string | undefined) ||
+                      undefined,
+                    avatar: creatorFromMap?.avatar,
+                  }
+                : creatorFromMap
               : undefined,
+            updater:
+              updaterSnapshotId ||
+              secret.last_updated_by_name ||
+              secret.last_updated_by_email
+                ? secret.last_updated_by_name || secret.last_updated_by_email
+                  ? {
+                      id: updaterSnapshotId || "",
+                      email:
+                        (secret.last_updated_by_email as string | undefined) ||
+                        "",
+                      username:
+                        (secret.last_updated_by_name as string | undefined) ||
+                        undefined,
+                      avatar: updaterFromMap?.avatar,
+                    }
+                  : updaterFromMap
+                : undefined,
           },
         };
       }),

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -7,6 +7,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { headers } from "next/headers";
 import { authRateLimit } from "@/lib/ratelimit";
+import { logAuditEvent } from "@/lib/audit-logger";
 
 export async function signInWithGoogle(formData?: FormData) {
   const supabase = await createClient();
@@ -149,7 +150,83 @@ export async function deleteAccountAction() {
   const { createAdminClient } = await import("@/lib/supabase/admin");
   const adminSupabase = createAdminClient();
 
-  // 0. Clean up user memberships and shared access
+  const { data: profileData } = await adminSupabase
+    .from("profiles")
+    .select("username")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  const actorName =
+    profileData?.username ||
+    (typeof user.user_metadata?.username === "string"
+      ? user.user_metadata.username
+      : undefined) ||
+    (typeof user.user_metadata?.name === "string"
+      ? user.user_metadata.name
+      : undefined) ||
+    null;
+  const actorEmail = user.email ?? null;
+  const actorDisplayName =
+    actorName || actorEmail?.split("@")[0] || `user-${user.id.slice(0, 8)}`;
+
+  // 0. Reassign shared ownership references before deleting the auth user.
+  const { error: preparationError } = await adminSupabase.rpc(
+    "prepare_user_account_deletion",
+    {
+      p_user_id: user.id,
+      p_actor_name: actorName,
+      p_actor_email: actorEmail,
+    },
+  );
+
+  if (preparationError) {
+    console.error(
+      "Error preparing account deletion (reassignment/audit snapshot):",
+      preparationError,
+    );
+    return {
+      error:
+        "Failed to prepare account deletion safely. Please try again or contact support.",
+    };
+  }
+
+  // 0.5. Emit membership removal audit events before membership rows are deleted
+  // so project owners have a clear trail that this member account was deleted.
+  const { data: memberships } = await adminSupabase
+    .from("project_members")
+    .select("project_id, projects!inner(name)")
+    .eq("user_id", user.id);
+
+  if (memberships && memberships.length > 0) {
+    await Promise.allSettled(
+      memberships.map((membership) => {
+        const projectName =
+          (membership.projects as unknown as { name?: string })?.name ||
+          "Project";
+
+        return logAuditEvent({
+          projectId: membership.project_id,
+          actorId: user.id,
+          actorType: "user",
+          action: "member.removed",
+          targetResourceId: user.id,
+          metadata: {
+            actor_name: actorDisplayName,
+            actor_email: actorEmail || "",
+            member_user_id: user.id,
+            beneficiary_user_id: user.id,
+            beneficiary_name: actorDisplayName,
+            beneficiary_email: actorEmail || "",
+            project_name: projectName,
+            reason: "account_deleted",
+            initiated_by: "self",
+          },
+        });
+      }),
+    );
+  }
+
+  // 1. Clean up user memberships and shared access
   // We must clean these up explicitly because they might be on projects/secrets NOT owned by the user,
   // or the foreign keys might not be set to CASCADE for these specific relationships.
 
@@ -175,16 +252,6 @@ export async function deleteAccountAction() {
   if (memberError)
     console.error("Error deleting project memberships:", memberError);
 
-  // Project Members (where user added someone else)
-  // If we don't delete these, the 'added_by' foreign key constraint will fail.
-  // Ideally we would transfer these to the owner, but deleting is acceptable for account deletion.
-  const { error: addedByError } = await adminSupabase
-    .from("project_members")
-    .delete()
-    .eq("added_by", user.id);
-  if (addedByError)
-    console.error("Error deleting members added by user:", addedByError);
-
   // Secrets (where user updated them but doesn't own them)
   // We must NULL out the reference, otherwise we can't delete the user.
   // We do NOT want to delete the secret itself as it belongs to someone else.
@@ -195,17 +262,6 @@ export async function deleteAccountAction() {
 
   if (updatedByError)
     console.error("Error nullifying updated_by:", updatedByError);
-
-  // 1. Delete user's secrets
-  const { error: secretsError } = await adminSupabase
-    .from("secrets")
-    .delete()
-    .eq("user_id", user.id);
-
-  if (secretsError) {
-    console.error("Error deleting user secrets:", secretsError);
-    return { error: "Failed to clean up user data (secrets)" };
-  }
 
   // 2. Delete user's projects
   const { error: projectsError } = await adminSupabase

--- a/src/app/api/avatar/route.ts
+++ b/src/app/api/avatar/route.ts
@@ -1,0 +1,143 @@
+import { createHash } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { avatarProxyRateLimit } from "@/lib/ratelimit";
+import { redis } from "@/lib/redis";
+
+const CACHE_TTL_SECONDS = 60 * 60 * 6;
+const ALLOWED_HOSTS = new Set([
+  "lh3.googleusercontent.com",
+  "lh4.googleusercontent.com",
+  "lh5.googleusercontent.com",
+  "lh6.googleusercontent.com",
+  "avatars.githubusercontent.com",
+  "secure.gravatar.com",
+]);
+
+function getClientIp(request: NextRequest): string {
+  const forwardedFor = request.headers.get("x-forwarded-for") || "";
+  const firstIp = forwardedFor.split(",")[0]?.trim();
+  return firstIp || "unknown";
+}
+
+function isAllowedAvatarUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:") {
+      return false;
+    }
+
+    if (ALLOWED_HOSTS.has(url.hostname)) {
+      return true;
+    }
+
+    // Allow any subdomain of googleusercontent.com used by Google profile photos.
+    return url.hostname.endsWith(".googleusercontent.com");
+  } catch {
+    return false;
+  }
+}
+
+function cacheKeyFor(url: string): string {
+  const hash = createHash("sha256").update(url).digest("hex");
+  return `avatar:proxy:${hash}`;
+}
+
+function invalidRequest(message: string): NextResponse {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+export async function GET(request: NextRequest) {
+  const avatarUrl = request.nextUrl.searchParams.get("url") || "";
+
+  if (!avatarUrl) {
+    return invalidRequest("Missing avatar URL");
+  }
+
+  if (avatarUrl.length > 2048) {
+    return invalidRequest("Avatar URL is too long");
+  }
+
+  if (!isAllowedAvatarUrl(avatarUrl)) {
+    return invalidRequest("Avatar URL host is not allowed");
+  }
+
+  const ip = getClientIp(request);
+  const { success } = await avatarProxyRateLimit.limit(`avatar_proxy_${ip}`);
+  if (!success) {
+    return NextResponse.json(
+      { error: "Too many avatar requests. Please try again shortly." },
+      { status: 429 },
+    );
+  }
+
+  const key = cacheKeyFor(avatarUrl);
+
+  try {
+    const [cachedBody, cachedType] = await Promise.all([
+      redis.get<string>(`${key}:body`),
+      redis.get<string>(`${key}:type`),
+    ]);
+
+    if (cachedBody && cachedType) {
+      const bodyBuffer = Buffer.from(cachedBody, "base64");
+      return new NextResponse(bodyBuffer, {
+        status: 200,
+        headers: {
+          "Content-Type": cachedType,
+          "Cache-Control":
+            "public, max-age=3600, s-maxage=21600, stale-while-revalidate=86400",
+          "X-Avatar-Cache": "hit",
+        },
+      });
+    }
+  } catch {
+    // Continue to upstream fetch if Redis is temporarily unavailable.
+  }
+
+  const upstream = await fetch(avatarUrl, {
+    headers: {
+      "User-Agent": "EnvaultAvatarProxy/1.0",
+      Accept: "image/*,*/*;q=0.8",
+    },
+    cache: "no-store",
+  });
+
+  if (!upstream.ok) {
+    return NextResponse.json(
+      { error: "Failed to fetch avatar from upstream" },
+      { status: upstream.status },
+    );
+  }
+
+  const contentType = upstream.headers.get("content-type") || "image/jpeg";
+  const bodyArrayBuffer = await upstream.arrayBuffer();
+  const bodyBuffer = Buffer.from(bodyArrayBuffer);
+
+  if (bodyBuffer.length > 1024 * 1024) {
+    return NextResponse.json(
+      { error: "Avatar file too large" },
+      { status: 413 },
+    );
+  }
+
+  try {
+    await Promise.all([
+      redis.set(`${key}:body`, bodyBuffer.toString("base64"), {
+        ex: CACHE_TTL_SECONDS,
+      }),
+      redis.set(`${key}:type`, contentType, { ex: CACHE_TTL_SECONDS }),
+    ]);
+  } catch {
+    // Caching failures should not block the avatar response.
+  }
+
+  return new NextResponse(bodyBuffer, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control":
+        "public, max-age=3600, s-maxage=21600, stale-while-revalidate=86400",
+      "X-Avatar-Cache": "miss",
+    },
+  });
+}

--- a/src/app/api/project/[projectId]/audit-logs/route.ts
+++ b/src/app/api/project/[projectId]/audit-logs/route.ts
@@ -42,7 +42,10 @@ function normalizeEnvValue(value: unknown): string[] | "all" | null {
   return null;
 }
 
-function getEnvAccessState(value: unknown): { state: EnvAccessState; key: string } {
+function getEnvAccessState(value: unknown): {
+  state: EnvAccessState;
+  key: string;
+} {
   const normalized = normalizeEnvValue(value);
   if (normalized === "all") {
     return { state: "all", key: "all" };
@@ -122,7 +125,8 @@ export async function GET(
     }
 
     const url = new URL(req.url);
-    const actorId = url.searchParams.get("actor_id") || url.searchParams.get("user_id");
+    const actorId =
+      url.searchParams.get("actor_id") || url.searchParams.get("user_id");
     const action = url.searchParams.get("action");
     const isEnvAccessFilter =
       action === "environment.access_granted" ||
@@ -151,14 +155,19 @@ export async function GET(
     const role = await getProjectRole(supabase, projectId, user.id);
     if (!role) {
       return NextResponse.json(
-        { error: "Forbidden: You do not have access to this project's audit logs" },
+        {
+          error:
+            "Forbidden: You do not have access to this project's audit logs",
+        },
         { status: 403 },
       );
     }
 
     let query = supabase
       .from("audit_logs")
-      .select("id, created_at, project_id, actor_id, actor_type, action, target_resource_id, user_agent, metadata")
+      .select(
+        "id, created_at, project_id, actor_id, actor_type, action, target_resource_id, user_agent, metadata",
+      )
       .eq("project_id", projectId)
       .order("created_at", { ascending: false })
       .limit(100);
@@ -250,6 +259,7 @@ export async function GET(
         const fallbackName =
           (authUser.user_metadata?.username as string | undefined) ||
           (authUser.user_metadata?.name as string | undefined) ||
+          authUser.email?.split("@")[0] ||
           "Former Member";
 
         if (!userNameById.has(authUser.id)) {
@@ -281,10 +291,26 @@ export async function GET(
     }
 
     const enrichedLogs = (logs || []).map((log) => {
+      const rawMetadata =
+        log.metadata && typeof log.metadata === "object"
+          ? (log.metadata as Record<string, unknown>)
+          : {};
+      const metadataActorName =
+        typeof rawMetadata.actor_name === "string"
+          ? rawMetadata.actor_name
+          : "";
+      const metadataActorEmail =
+        typeof rawMetadata.actor_email === "string"
+          ? rawMetadata.actor_email
+          : "";
+
       const actorName =
         log.actor_type === "machine"
           ? machineNameById.get(log.actor_id) || "Service Token"
-          : userNameById.get(log.actor_id) || "Former Member";
+          : userNameById.get(log.actor_id) ||
+            metadataActorName ||
+            metadataActorEmail ||
+            "Former Member";
 
       const metadata =
         log.metadata && typeof log.metadata === "object"
@@ -298,16 +324,32 @@ export async function GET(
         parseMaybeUuid(metadata.beneficiary_user_id);
 
       if (beneficiaryUserId) {
+        const existingBeneficiaryName =
+          typeof metadata.beneficiary_name === "string"
+            ? metadata.beneficiary_name
+            : "";
+        const existingBeneficiaryEmail =
+          typeof metadata.beneficiary_email === "string"
+            ? metadata.beneficiary_email
+            : "";
+
         metadata.beneficiary_user_id = beneficiaryUserId;
         metadata.beneficiary_name =
-          userNameById.get(beneficiaryUserId) || "Former Member";
-        metadata.beneficiary_email = userEmailById.get(beneficiaryUserId) || "";
+          userNameById.get(beneficiaryUserId) ||
+          existingBeneficiaryName ||
+          existingBeneficiaryEmail ||
+          "Former Member";
+        metadata.beneficiary_email =
+          userEmailById.get(beneficiaryUserId) ||
+          existingBeneficiaryEmail ||
+          "";
       }
 
       return {
         ...log,
         actor_name: actorName,
-        actor_email: userEmailById.get(log.actor_id) || "",
+        actor_email:
+          userEmailById.get(log.actor_id) || metadataActorEmail || "",
         actor_avatar: userAvatarById.get(log.actor_id) || "",
         metadata,
       };
@@ -320,7 +362,9 @@ export async function GET(
               log.metadata && typeof log.metadata === "object"
                 ? (log.metadata as Record<string, unknown>)
                 : {};
-            return deriveEnvironmentAccessAction(log.action, metadata) === action;
+            return (
+              deriveEnvironmentAccessAction(log.action, metadata) === action
+            );
           })
         : enrichedLogs;
 

--- a/src/app/approve/[requestId]/approve-form.tsx
+++ b/src/app/approve/[requestId]/approve-form.tsx
@@ -47,9 +47,9 @@ export function ApproveForm({
     return merged.filter((env) => environments.includes(env));
   }, [environments, existingAllowedEnvironments, requestedEnvironment]);
 
-  const [selectedEnvironments, setSelectedEnvironments] = React.useState<string[]>(
-    () => getInitialSelectedEnvironments(),
-  );
+  const [selectedEnvironments, setSelectedEnvironments] = React.useState<
+    string[]
+  >(() => getInitialSelectedEnvironments());
 
   React.useEffect(() => {
     setRole(existingRole);
@@ -57,8 +57,21 @@ export function ApproveForm({
   }, [existingRole, getInitialSelectedEnvironments]);
 
   const handleApprove = async () => {
+    if (environments.length > 0 && selectedEnvironments.length === 0) {
+      toast.error("Select at least one environment before approving access.");
+      return;
+    }
+
+    const environmentPayload =
+      environments.length > 0 ? selectedEnvironments : undefined;
+
     setIsApproving(true);
-    const result = await approveRequest(requestId, role, true, selectedEnvironments);
+    const result = await approveRequest(
+      requestId,
+      role,
+      true,
+      environmentPayload,
+    );
     if (result.error) {
       toast.error(result.error);
       setIsApproving(false);
@@ -97,7 +110,10 @@ export function ApproveForm({
               {environments.map((env) => {
                 const isChecked = selectedEnvironments.includes(env);
                 return (
-                  <div key={`approve-${requestId}-${env}`} className="flex items-center space-x-2">
+                  <div
+                    key={`approve-${requestId}-${env}`}
+                    className="flex items-center space-x-2"
+                  >
                     <Checkbox
                       id={`approve-${requestId}-${env}`}
                       className="rounded border-1"
@@ -107,7 +123,9 @@ export function ApproveForm({
                         if (checked) {
                           nextEnvs = [...selectedEnvironments, env];
                         } else {
-                          nextEnvs = selectedEnvironments.filter((e) => e !== env);
+                          nextEnvs = selectedEnvironments.filter(
+                            (e) => e !== env,
+                          );
                         }
                         setSelectedEnvironments(nextEnvs);
                       }}

--- a/src/app/invite-actions.ts
+++ b/src/app/invite-actions.ts
@@ -249,7 +249,7 @@ export async function approveRequest(
   // Fetch request details
   const { data: request, error: requestError } = await admin
     .from("access_requests")
-    .select("*, projects!inner(user_id, name)")
+    .select("*, projects!inner(user_id, name, ui_mode)")
     .eq("id", requestId)
     .single();
 
@@ -258,11 +258,38 @@ export async function approveRequest(
   }
 
   // Verify User is Owner of the Project
-  const projectOwner = (request.projects as unknown as { user_id: string })
-    .user_id;
+  const requestProject = request.projects as unknown as {
+    user_id: string;
+    name: string;
+    ui_mode?: string | null;
+  };
+  const projectOwner = requestProject.user_id;
   if (projectOwner !== user.id) {
     return { error: "Unauthorized." };
   }
+
+  const isAdvancedMode = requestProject.ui_mode === "advanced";
+
+  const [{ data: requestedMemberProfile }, { data: requestedMemberAuth }] =
+    await Promise.all([
+      admin
+        .from("profiles")
+        .select("username")
+        .eq("id", request.user_id)
+        .maybeSingle(),
+      admin.auth.admin.getUserById(request.user_id),
+    ]);
+  const requestedMemberEmail = requestedMemberAuth?.user?.email || "";
+  const requestedMemberName =
+    requestedMemberProfile?.username ||
+    (typeof requestedMemberAuth?.user?.user_metadata?.username === "string"
+      ? requestedMemberAuth.user.user_metadata.username
+      : undefined) ||
+    (typeof requestedMemberAuth?.user?.user_metadata?.name === "string"
+      ? requestedMemberAuth.user.user_metadata.name
+      : undefined) ||
+    requestedMemberEmail.split("@")[0] ||
+    `user-${request.user_id.slice(0, 8)}`;
 
   // Check if user is already a member
   const { data: existingMember } = await admin
@@ -278,10 +305,13 @@ export async function approveRequest(
     const mergedRole: "viewer" | "editor" =
       roleRank(role) > roleRank(existingRole) ? role : existingRole;
 
-    const existingAllowed =
-      existingMember.allowed_environments as string[] | null | undefined;
-    const mergedAllowedEnvironments =
-      existingAllowed === null || existingAllowed === undefined
+    const existingAllowed = existingMember.allowed_environments as
+      | string[]
+      | null
+      | undefined;
+    const mergedAllowedEnvironments = !isAdvancedMode
+      ? null
+      : existingAllowed === null || existingAllowed === undefined
         ? null
         : allowedEnvironments
           ? Array.from(new Set([...existingAllowed, ...allowedEnvironments]))
@@ -311,6 +341,9 @@ export async function approveRequest(
         targetResourceId: request.user_id,
         metadata: {
           member_user_id: request.user_id,
+          beneficiary_user_id: request.user_id,
+          beneficiary_name: requestedMemberName,
+          beneficiary_email: requestedMemberEmail,
           project_name: projectName,
           changes: {
             role: {
@@ -336,6 +369,8 @@ export async function approveRequest(
         metadata: {
           member_user_id: request.user_id,
           beneficiary_user_id: request.user_id,
+          beneficiary_name: requestedMemberName,
+          beneficiary_email: requestedMemberEmail,
           project_name: projectName,
           changes: {
             allowed_environments: {
@@ -377,9 +412,8 @@ export async function approveRequest(
           );
         }
 
-        const { createAccessGrantedNotification } = await import(
-          "@/lib/notifications"
-        );
+        const { createAccessGrantedNotification } =
+          await import("@/lib/notifications");
         await createAccessGrantedNotification(
           request.user_id,
           projectName,
@@ -388,7 +422,10 @@ export async function approveRequest(
           mergedAllowedEnvironments,
         );
       } catch (notifyError) {
-        console.error("Failed to notify existing member approval update:", notifyError);
+        console.error(
+          "Failed to notify existing member approval update:",
+          notifyError,
+        );
       }
     }
 
@@ -403,19 +440,24 @@ export async function approveRequest(
     added_by: user.id,
   };
 
-  if (allowedEnvironments !== undefined) {
+  if (!isAdvancedMode) {
+    insertData.allowed_environments = null;
+  } else if (allowedEnvironments !== undefined) {
     insertData.allowed_environments = allowedEnvironments;
   }
 
-  const { error: memberError } = await admin.from("project_members").insert(insertData);
+  const { error: memberError } = await admin
+    .from("project_members")
+    .insert(insertData);
 
   if (memberError) {
     return { error: memberError.message };
   }
 
-  const projectNameForAudit = (request.projects as unknown as { name: string })
-    .name;
-  const normalizedAllowed = normalizeAllowedEnvironments(allowedEnvironments);
+  const projectNameForAudit = requestProject.name;
+  const normalizedAllowed = normalizeAllowedEnvironments(
+    isAdvancedMode ? allowedEnvironments : null,
+  );
 
   await logAuditEvent({
     projectId: request.project_id!,
@@ -426,6 +468,8 @@ export async function approveRequest(
     metadata: {
       member_user_id: request.user_id,
       beneficiary_user_id: request.user_id,
+      beneficiary_name: requestedMemberName,
+      beneficiary_email: requestedMemberEmail,
       role,
       project_name: projectNameForAudit,
     },
@@ -439,6 +483,9 @@ export async function approveRequest(
     targetResourceId: request.user_id,
     metadata: {
       member_user_id: request.user_id,
+      beneficiary_user_id: request.user_id,
+      beneficiary_name: requestedMemberName,
+      beneficiary_email: requestedMemberEmail,
       project_name: projectNameForAudit,
       changes: {
         allowed_environments: {
@@ -632,6 +679,11 @@ export async function removeMember(projectId: string, memberUserId: string) {
       admin.auth.admin.getUserById(memberUserId),
       admin.auth.admin.getUserById(user.id),
     ]);
+  const { data: removedUserProfile } = await admin
+    .from("profiles")
+    .select("username")
+    .eq("id", memberUserId)
+    .maybeSingle();
   const { data: actorProfile } = await admin
     .from("profiles")
     .select("username")
@@ -643,6 +695,17 @@ export async function removeMember(projectId: string, memberUserId: string) {
     actorProfile?.username ||
     actorUser?.user?.user_metadata?.username ||
     "Owner";
+  const removedUserEmail = removedUser?.user?.email || "";
+  const removedUserName =
+    removedUserProfile?.username ||
+    (typeof removedUser?.user?.user_metadata?.username === "string"
+      ? removedUser.user.user_metadata.username
+      : undefined) ||
+    (typeof removedUser?.user?.user_metadata?.name === "string"
+      ? removedUser.user.user_metadata.name
+      : undefined) ||
+    removedUserEmail.split("@")[0] ||
+    `user-${memberUserId.slice(0, 8)}`;
 
   const { error } = await supabase
     .from("project_members")
@@ -660,6 +723,9 @@ export async function removeMember(projectId: string, memberUserId: string) {
     targetResourceId: memberUserId,
     metadata: {
       member_user_id: memberUserId,
+      beneficiary_user_id: memberUserId,
+      beneficiary_name: removedUserName,
+      beneficiary_email: removedUserEmail,
       project_name: projectName,
     },
   });
@@ -672,6 +738,9 @@ export async function removeMember(projectId: string, memberUserId: string) {
     targetResourceId: memberUserId,
     metadata: {
       member_user_id: memberUserId,
+      beneficiary_user_id: memberUserId,
+      beneficiary_name: removedUserName,
+      beneficiary_email: removedUserEmail,
       project_name: projectName,
       changes: {
         allowed_environments: {
@@ -690,9 +759,8 @@ export async function removeMember(projectId: string, memberUserId: string) {
   await invalidateUserSecretAccess(memberUserId);
 
   try {
-    const { createMemberRemovedNotification } = await import(
-      "@/lib/notifications"
-    );
+    const { createMemberRemovedNotification } =
+      await import("@/lib/notifications");
     const { sendAccessRevokedEmail } = await import("@/lib/email");
 
     await createMemberRemovedNotification(memberUserId, projectName, removedBy);
@@ -734,17 +802,28 @@ export async function updateMemberRole(
   const { createAdminClient } = await import("@/lib/supabase/admin");
   const admin = createAdminClient();
 
-  const [{ data: existingMember }, { data: projectData }, { data: actorUser }] =
-    await Promise.all([
-      admin
-        .from("project_members")
-        .select("role, allowed_environments")
-        .eq("project_id", projectId)
-        .eq("user_id", memberUserId)
-        .single(),
-      admin.from("projects").select("name, slug").eq("id", projectId).single(),
-      admin.auth.admin.getUserById(user.id),
-    ]);
+  const [
+    { data: existingMember },
+    { data: projectData },
+    { data: actorUser },
+    { data: memberUser },
+    { data: memberProfile },
+  ] = await Promise.all([
+    admin
+      .from("project_members")
+      .select("role, allowed_environments")
+      .eq("project_id", projectId)
+      .eq("user_id", memberUserId)
+      .single(),
+    admin.from("projects").select("name, slug").eq("id", projectId).single(),
+    admin.auth.admin.getUserById(user.id),
+    admin.auth.admin.getUserById(memberUserId),
+    admin
+      .from("profiles")
+      .select("username")
+      .eq("id", memberUserId)
+      .maybeSingle(),
+  ]);
   const { data: actorProfile } = await admin
     .from("profiles")
     .select("username")
@@ -760,6 +839,17 @@ export async function updateMemberRole(
     | string[]
     | null
     | undefined;
+  const memberEmail = memberUser?.user?.email || "";
+  const memberName =
+    memberProfile?.username ||
+    (typeof memberUser?.user?.user_metadata?.username === "string"
+      ? memberUser.user.user_metadata.username
+      : undefined) ||
+    (typeof memberUser?.user?.user_metadata?.name === "string"
+      ? memberUser.user.user_metadata.name
+      : undefined) ||
+    memberEmail.split("@")[0] ||
+    `user-${memberUserId.slice(0, 8)}`;
 
   const updateData: Record<string, unknown> = { role: newRole };
 
@@ -788,8 +878,13 @@ export async function updateMemberRole(
   }
 
   if (!data || data.length === 0) {
-    console.error("updateMemberRole: No rows updated. Possibly an RLS issue or mismatched IDs.");
-    return { error: "No rows were updated. Check permissions or if the user exists in the project." };
+    console.error(
+      "updateMemberRole: No rows updated. Possibly an RLS issue or mismatched IDs.",
+    );
+    return {
+      error:
+        "No rows were updated. Check permissions or if the user exists in the project.",
+    };
   }
 
   const nextAllowed = allowedEnvironments ?? previousAllowed ?? null;
@@ -803,6 +898,9 @@ export async function updateMemberRole(
       targetResourceId: memberUserId,
       metadata: {
         member_user_id: memberUserId,
+        beneficiary_user_id: memberUserId,
+        beneficiary_name: memberName,
+        beneficiary_email: memberEmail,
         project_name: projectData?.name || "Project",
         changes: {
           role: {
@@ -825,6 +923,8 @@ export async function updateMemberRole(
       metadata: {
         member_user_id: memberUserId,
         beneficiary_user_id: memberUserId,
+        beneficiary_name: memberName,
+        beneficiary_email: memberEmail,
         project_name: projectData?.name || "Project",
         changes: {
           allowed_environments: {
@@ -842,12 +942,9 @@ export async function updateMemberRole(
   await invalidateUserSecretAccess(memberUserId);
 
   try {
-    const { createRoleChangedNotification } = await import(
-      "@/lib/notifications"
-    );
+    const { createRoleChangedNotification } =
+      await import("@/lib/notifications");
     const { sendAccessUpdatedEmail } = await import("@/lib/email");
-    const { data: memberUser } = await admin.auth.admin.getUserById(memberUserId);
-
     const projectName = projectData?.name || "Project";
     const projectSlug = projectData?.slug || projectId;
     const changedBy =
@@ -879,7 +976,10 @@ export async function updateMemberRole(
       );
     }
   } catch (notifyError) {
-    console.error("Failed to send role/environment update notifications:", notifyError);
+    console.error(
+      "Failed to send role/environment update notifications:",
+      notifyError,
+    );
   }
 
   revalidatePath("/project/[slug]", "page");

--- a/src/app/project-actions.ts
+++ b/src/app/project-actions.ts
@@ -40,6 +40,68 @@ async function resolveProjectEnvironmentForUI(
   return null;
 }
 
+async function touchProjectActivity(projectId: string) {
+  const admin = createAdminClient();
+
+  await admin
+    .from("projects")
+    .update({ last_updated_at: new Date().toISOString() })
+    .eq("id", projectId);
+
+  const [{ data: project }, { data: members }] = await Promise.all([
+    admin.from("projects").select("user_id").eq("id", projectId).maybeSingle(),
+    admin.from("project_members").select("user_id").eq("project_id", projectId),
+  ]);
+
+  const userIds = new Set<string>();
+  if (project?.user_id) userIds.add(project.user_id);
+  (members || []).forEach((member) => {
+    if (member.user_id) userIds.add(member.user_id);
+  });
+
+  const { cacheDel, CacheKeys, invalidateProjectCaches } =
+    await import("@/lib/cache");
+
+  await Promise.all([
+    ...Array.from(userIds).map((userId) =>
+      cacheDel(CacheKeys.userProjects(userId)),
+    ),
+    invalidateProjectCaches(projectId),
+  ]);
+}
+
+async function getActorIdentitySnapshot(userId: string, fallbackEmail: string) {
+  const admin = createAdminClient();
+
+  const [{ data: profile }, { data: authUser }] = await Promise.all([
+    admin.from("profiles").select("username").eq("id", userId).maybeSingle(),
+    admin.auth.admin.getUserById(userId),
+  ]);
+
+  const email = authUser?.user?.email || fallbackEmail || "";
+  const metadata = authUser?.user?.user_metadata || {};
+  const usernameFromProfile =
+    profile && typeof profile.username === "string" ? profile.username : "";
+  const usernameFromMetadata =
+    typeof metadata.username === "string"
+      ? metadata.username
+      : typeof metadata.name === "string"
+        ? metadata.name
+        : "";
+
+  const name =
+    usernameFromProfile ||
+    usernameFromMetadata ||
+    email.split("@")[0] ||
+    `user-${userId.slice(0, 8)}`;
+
+  return {
+    id: userId,
+    name,
+    email,
+  };
+}
+
 export async function createProject(
   name: string,
   options?: {
@@ -74,7 +136,9 @@ export async function createProject(
     .maybeSingle();
 
   if (existingProject) {
-    return { error: `A project named "${name}" already exists. Please use a different name.` };
+    return {
+      error: `A project named "${name}" already exists. Please use a different name.`,
+    };
   }
 
   const slugBase =
@@ -196,9 +260,8 @@ export async function renameProject(id: string, newName: string) {
   }
 
   // Invalidate user's project list cache and specific project cache
-  const { cacheDel, CacheKeys, invalidateProjectCaches } = await import(
-    "@/lib/cache"
-  );
+  const { cacheDel, CacheKeys, invalidateProjectCaches } =
+    await import("@/lib/cache");
   await cacheDel(CacheKeys.userProjects(user.id));
   await invalidateProjectCaches(id);
 
@@ -217,7 +280,7 @@ export async function renameProject(id: string, newName: string) {
         `Your project has been renamed to "${data.name}"`,
         data.id,
         user.id,
-      ).catch(() => { });
+      ).catch(() => {});
     }
   }
 
@@ -236,9 +299,8 @@ export async function getProjects(bypassCache: boolean = false) {
   }
 
   // Check cache first
-  const { cacheGet, cacheSet, CacheKeys, CACHE_TTL } = await import(
-    "@/lib/cache"
-  );
+  const { cacheGet, cacheSet, CacheKeys, CACHE_TTL } =
+    await import("@/lib/cache");
   const cacheKey = CacheKeys.userProjects(user.id);
 
   if (!bypassCache) {
@@ -340,7 +402,10 @@ export async function getProjects(bypassCache: boolean = false) {
   // Create membership map
   const membershipMap = new Map<
     string,
-    { role: "owner" | "editor" | "viewer"; allowed_environments: string[] | null }
+    {
+      role: "owner" | "editor" | "viewer";
+      allowed_environments: string[] | null;
+    }
   >(
     memberships?.map((m) => [
       m.project_id,
@@ -403,11 +468,14 @@ export async function getProjects(bypassCache: boolean = false) {
     .select("id, project_id, name, slug, is_default");
 
   // Group environments by project
-  const environmentMap = new Map<string, Array<{ id: string, slug: string, name: string, is_default: boolean }>>();
+  const environmentMap = new Map<
+    string,
+    Array<{ id: string; slug: string; name: string; is_default: boolean }>
+  >();
   const environmentSlugByIdMap = new Map<string, string>();
 
   if (allEnvironments) {
-    allEnvironments.forEach(env => {
+    allEnvironments.forEach((env) => {
       const projEnvs = environmentMap.get(env.project_id) || [];
       projEnvs.push(env);
       environmentMap.set(env.project_id, projEnvs);
@@ -424,8 +492,13 @@ export async function getProjects(bypassCache: boolean = false) {
 
   const sharedSecretIdMap = new Map<string, Set<string>>();
   userSecretShares?.forEach((share) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const secret = Array.isArray(share.secrets) ? share.secrets[0] : (share.secrets as any);
+      const secretRelation = share.secrets as
+        | { project_id?: string }
+        | Array<{ project_id?: string }>
+        | null;
+      const secret = Array.isArray(secretRelation)
+        ? secretRelation[0]
+        : secretRelation;
     const projectId = secret?.project_id as string | undefined;
     if (!projectId) return;
     const ids = sharedSecretIdMap.get(projectId) || new Set<string>();
@@ -485,15 +558,30 @@ export async function getProjects(bypassCache: boolean = false) {
       ui_mode: p.ui_mode || "simple",
       default_environment_slug: p.default_environment_slug || "development",
       owner_username: ownerUsernameMap.get(p.user_id) || null,
-      createdAt: p.created_at || new Date().toISOString(), // Fallback for safety
+      createdAt: p.last_updated_at || p.created_at || new Date().toISOString(), // Activity timestamp for dashboard card
       secretCount: count,
       variables: [],
       role,
       isShared,
       environments: environmentMap.get(p.id) || [
-        { id: "dev-fallback", slug: "development", name: "Development", is_default: true },
-        { id: "prev-fallback", slug: "preview", name: "Preview", is_default: false },
-        { id: "prod-fallback", slug: "production", name: "Production", is_default: false },
+        {
+          id: "dev-fallback",
+          slug: "development",
+          name: "Development",
+          is_default: true,
+        },
+        {
+          id: "prev-fallback",
+          slug: "preview",
+          name: "Preview",
+          is_default: false,
+        },
+        {
+          id: "prod-fallback",
+          slug: "production",
+          name: "Production",
+          is_default: false,
+        },
       ],
     };
   });
@@ -540,9 +628,8 @@ export async function deleteProject(id: string) {
   }
 
   // Invalidate caches for owner and all members
-  const { cacheDel, CacheKeys, invalidateProjectCaches } = await import(
-    "@/lib/cache"
-  );
+  const { cacheDel, CacheKeys, invalidateProjectCaches } =
+    await import("@/lib/cache");
   await cacheDel(CacheKeys.userProjects(user.id));
   await invalidateProjectCaches(id);
 
@@ -577,6 +664,11 @@ export async function addVariable(
   if (!user) {
     return { error: "Not authenticated" };
   }
+
+  const actorSnapshot = await getActorIdentitySnapshot(
+    user.id,
+    user.email || "",
+  );
 
   // Rate Limiting
   const ip = (await headers()).get("x-forwarded-for") || "unknown";
@@ -618,12 +710,18 @@ export async function addVariable(
     .from("secrets")
     .insert({
       user_id: user.id, // Creator
+      created_by_user_id_snapshot: actorSnapshot.id,
+      created_by_name: actorSnapshot.name,
+      created_by_email: actorSnapshot.email,
       project_id: projectId,
       environment_id: environment.id,
       key,
       value: encryptedValue,
       key_id: keyId,
       last_updated_by: user.id,
+      last_updated_by_user_id_snapshot: actorSnapshot.id,
+      last_updated_by_name: actorSnapshot.name,
+      last_updated_by_email: actorSnapshot.email,
       last_updated_at: new Date().toISOString(),
     })
     .select()
@@ -655,7 +753,7 @@ export async function addVariable(
           `A new secret <strong>${key}</strong> was added to <strong>${projectData.name}</strong>`,
           projectData.id,
           user.id,
-        ).catch(() => { });
+        ).catch(() => {});
       }
     }
   }
@@ -672,6 +770,8 @@ export async function addVariable(
       beneficiary_user_id: user.id,
     },
   });
+
+  await touchProjectActivity(projectId);
 
   revalidatePath("/project/[slug]", "page");
   return { data };
@@ -707,6 +807,11 @@ export async function updateVariable(
   if (!user) {
     return { error: "Not authenticated" };
   }
+
+  const actorSnapshot = await getActorIdentitySnapshot(
+    user.id,
+    user.email || "",
+  );
 
   // Rate Limiting
   const ip = (await headers()).get("x-forwarded-for") || "unknown";
@@ -758,6 +863,9 @@ export async function updateVariable(
   const finalUpdates: Record<string, unknown> = {
     ...updates,
     last_updated_by: user.id,
+    last_updated_by_user_id_snapshot: actorSnapshot.id,
+    last_updated_by_name: actorSnapshot.name,
+    last_updated_by_email: actorSnapshot.email,
     last_updated_at: new Date().toISOString(),
   };
 
@@ -800,7 +908,7 @@ export async function updateVariable(
           `A secret was updated in <strong>${projectData.name}</strong>`,
           projectData.id,
           user.id,
-        ).catch(() => { });
+        ).catch(() => {});
       }
     }
   }
@@ -832,6 +940,8 @@ export async function updateVariable(
       ...(Object.keys(changes).length > 0 ? { changes } : {}),
     },
   });
+
+  await touchProjectActivity(projectId);
 
   revalidatePath("/project/[slug]", "page");
   return { success: true };
@@ -916,7 +1026,7 @@ export async function deleteVariable(
           `A secret was deleted from <strong>${projectData.name}</strong>`,
           projectData.id,
           user.id,
-        ).catch(() => { });
+        ).catch(() => {});
       }
     }
   }
@@ -943,6 +1053,8 @@ export async function deleteVariable(
       },
     },
   });
+
+  await touchProjectActivity(projectId);
 
   revalidatePath("/project/[slug]", "page");
   return { success: true };
@@ -973,6 +1085,11 @@ export async function addVariablesBulk(
   if (!user) {
     return { added: 0, updated: 0, skipped: 0, error: "Not authenticated" };
   }
+
+  const actorSnapshot = await getActorIdentitySnapshot(
+    user.id,
+    user.email || "",
+  );
 
   // Rate Limiting
   const ip = (await headers()).get("x-forwarded-for") || "unknown";
@@ -1032,12 +1149,18 @@ export async function addVariablesBulk(
   const itemsToUpsert: Array<{
     id: string;
     user_id: string;
+    created_by_user_id_snapshot?: string;
+    created_by_name?: string;
+    created_by_email?: string;
     project_id: string;
     environment_id: string;
     key: string;
     value: string;
     key_id: string;
     last_updated_by: string;
+    last_updated_by_user_id_snapshot?: string;
+    last_updated_by_name?: string;
+    last_updated_by_email?: string;
     last_updated_at: string;
   }> = [];
 
@@ -1052,12 +1175,18 @@ export async function addVariablesBulk(
       itemsToUpsert.push({
         id: crypto.randomUUID(),
         user_id: user.id,
+        created_by_user_id_snapshot: actorSnapshot.id,
+        created_by_name: actorSnapshot.name,
+        created_by_email: actorSnapshot.email,
         project_id: projectId,
         environment_id: environment.id,
         key: variable.key,
         value: encryptedValue,
         key_id: keyId,
         last_updated_by: user.id,
+        last_updated_by_user_id_snapshot: actorSnapshot.id,
+        last_updated_by_name: actorSnapshot.name,
+        last_updated_by_email: actorSnapshot.email,
         last_updated_at: new Date().toISOString(),
       });
     } else {
@@ -1079,6 +1208,9 @@ export async function addVariablesBulk(
             value: encryptedValue,
             key_id: keyId,
             last_updated_by: user.id,
+            last_updated_by_user_id_snapshot: actorSnapshot.id,
+            last_updated_by_name: actorSnapshot.name,
+            last_updated_by_email: actorSnapshot.email,
             last_updated_at: new Date().toISOString(),
           });
         }
@@ -1098,6 +1230,9 @@ export async function addVariablesBulk(
           value: encryptedValue,
           key_id: keyId,
           last_updated_by: user.id,
+          last_updated_by_user_id_snapshot: actorSnapshot.id,
+          last_updated_by_name: actorSnapshot.name,
+          last_updated_by_email: actorSnapshot.email,
           last_updated_at: new Date().toISOString(),
         });
       }
@@ -1113,6 +1248,8 @@ export async function addVariablesBulk(
       console.error("Bulk upsert error:", error);
       return { added: 0, updated: 0, skipped: 0, error: error.message };
     }
+
+    await touchProjectActivity(projectId);
 
     // Fire-and-forget project activity email summarising the import
     {
@@ -1139,7 +1276,7 @@ export async function addVariablesBulk(
             `Bulk import to <strong>${projectData.name}</strong> finished: ${summary}, ${skipped} unchanged.`,
             projectData.id,
             user.id,
-          ).catch(() => { });
+          ).catch(() => {});
         }
       }
     }

--- a/src/app/project/[slug]/page.tsx
+++ b/src/app/project/[slug]/page.tsx
@@ -156,7 +156,8 @@ export default async function ProjectPage({ params, searchParams }: PageProps) {
   }
 
   const hasActiveEnvironmentAccess =
-    !allowedEnvironments || allowedEnvironments.includes(activeEnvironment.slug);
+    !allowedEnvironments ||
+    allowedEnvironments.includes(activeEnvironment.slug);
 
   let secrets: Array<{
     id: string;
@@ -324,12 +325,13 @@ export default async function ProjectPage({ params, searchParams }: PageProps) {
       project.default_environment_slug || activeEnvironment.slug,
     active_environment_slug: activeEnvironment.slug,
     environments: envList.map((env) => ({
-        id: env.id,
-        slug: env.slug,
-        name: env.name,
-        is_default: env.is_default,
-        can_access: !allowedEnvironments || allowedEnvironments.includes(env.slug),
-      })),
+      id: env.id,
+      slug: env.slug,
+      name: env.name,
+      is_default: env.is_default,
+      can_access:
+        !allowedEnvironments || allowedEnvironments.includes(env.slug),
+    })),
     createdAt: project.created_at,
     role: role,
     variables: await Promise.all(
@@ -357,12 +359,46 @@ export default async function ProjectPage({ params, searchParams }: PageProps) {
           }
         }
 
-        const creator = secret.user_id
+        const creatorFromMap = secret.user_id
           ? userMap.get(secret.user_id)
           : undefined;
-        const updater = secret.last_updated_by
+        const creator = secret.user_id
+          ? secret.created_by_name || secret.created_by_email
+            ? {
+                id:
+                  (secret.created_by_user_id_snapshot as string | undefined) ||
+                  secret.user_id,
+                email: (secret.created_by_email as string | undefined) || "",
+                username:
+                  (secret.created_by_name as string | undefined) || undefined,
+                avatar: creatorFromMap?.avatar,
+              }
+            : creatorFromMap
+          : undefined;
+
+        const updaterFromMap = secret.last_updated_by
           ? userMap.get(secret.last_updated_by)
           : undefined;
+        const updaterSnapshotId =
+          (secret.last_updated_by_user_id_snapshot as string | undefined) ||
+          secret.last_updated_by ||
+          undefined;
+        const updater =
+          updaterSnapshotId ||
+          secret.last_updated_by_name ||
+          secret.last_updated_by_email
+            ? secret.last_updated_by_name || secret.last_updated_by_email
+              ? {
+                  id: updaterSnapshotId || "",
+                  email:
+                    (secret.last_updated_by_email as string | undefined) || "",
+                  username:
+                    (secret.last_updated_by_name as string | undefined) ||
+                    undefined,
+                  avatar: updaterFromMap?.avatar,
+                }
+              : updaterFromMap
+            : undefined;
 
         return {
           id: secret.id,

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -139,7 +139,10 @@ export function AuthForm() {
         body: JSON.stringify({ response: asseResp, sessionId }),
       });
 
-      const verification = (await verifyResp.json()) as { success?: boolean; error?: string };
+      const verification = (await verifyResp.json()) as {
+        success?: boolean;
+        error?: string;
+      };
       if (verifyResp.ok && verification.success) {
         toast.success("Signed in with Passkey");
         const next = searchParams.get("next");
@@ -273,11 +276,16 @@ export function AuthForm() {
                     className="w-full flex items-center justify-center gap-2 border-primary/20 hover:bg-primary/5 hover:text-primary transition-colors"
                   >
                     {isPasskeyLoading ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <>
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Signing in with Passkey...
+                      </>
                     ) : (
-                      <Fingerprint className="h-4 w-4" />
+                      <>
+                        <Fingerprint className="h-4 w-4" />
+                        Sign in with Passkey
+                      </>
                     )}
-                    Sign in with Passkey
                   </Button>
                 </div>
 

--- a/src/components/dashboard/app-header.tsx
+++ b/src/components/dashboard/app-header.tsx
@@ -45,21 +45,8 @@ export function AppHeader({
   const router = useRouter();
 
   const handleBack = () => {
-    if (typeof window === "undefined") {
-      if (backTo) router.push(backTo);
-      return;
-    }
-
-    const hasHistory = window.history.length > 1;
-    const referrer = document.referrer;
-    const isInternalReferrer =
-      !!referrer && new URL(referrer).origin === window.location.origin;
-
-    if (hasHistory && isInternalReferrer) {
-      router.back();
-      return;
-    }
-
+    // Use explicit route back targets to avoid browser-history loops when
+    // users bounce between contextual pages (e.g. project <-> audit logs).
     if (backTo) {
       router.push(backTo);
       return;

--- a/src/components/dashboard/audit-logs-view.tsx
+++ b/src/components/dashboard/audit-logs-view.tsx
@@ -136,11 +136,13 @@ function getBeneficiaryLabel(metadata?: AuditLogMetadata): string | null {
 
 function getActionIcon(action: string) {
   if (action === "secret.created") return <KeyRound className="h-3.5 w-3.5" />;
-  if (action === "secret.updated") return <ShieldCheck className="h-3.5 w-3.5" />;
+  if (action === "secret.updated")
+    return <ShieldCheck className="h-3.5 w-3.5" />;
   if (action === "secret.deleted") return <Trash2 className="h-3.5 w-3.5" />;
   if (action === "secret.read_batch") return <Eye className="h-3.5 w-3.5" />;
   if (action === "member.invited") return <UserPlus className="h-3.5 w-3.5" />;
-  if (action === "member.role_updated") return <UserCog className="h-3.5 w-3.5" />;
+  if (action === "member.role_updated")
+    return <UserCog className="h-3.5 w-3.5" />;
   if (action === "member.removed") return <UserMinus className="h-3.5 w-3.5" />;
   if (action === "environment.access_updated")
     return <RefreshCw className="h-3.5 w-3.5" />;
@@ -170,7 +172,10 @@ function normalizeEnvValue(value: unknown): string[] | "all" | null {
 
 type EnvAccessState = "none" | "some" | "all" | "unknown";
 
-function getEnvAccessState(value: unknown): { state: EnvAccessState; key: string } {
+function getEnvAccessState(value: unknown): {
+  state: EnvAccessState;
+  key: string;
+} {
   const normalized = normalizeEnvValue(value);
   if (normalized === "all") {
     return { state: "all", key: "all" };
@@ -187,7 +192,11 @@ function getEnvAccessState(value: unknown): { state: EnvAccessState; key: string
 
 function getEnvironmentActionVariant(
   log: AuditLog,
-): "environment.access_granted" | "environment.access_revoked" | "environment.access_updated" | null {
+):
+  | "environment.access_granted"
+  | "environment.access_revoked"
+  | "environment.access_updated"
+  | null {
   if (
     log.action !== "environment.access_granted" &&
     log.action !== "environment.access_revoked"
@@ -225,17 +234,31 @@ function getEffectiveAction(log: AuditLog): string {
 }
 
 function isMemberRelatedAction(action: string): boolean {
-  return action.startsWith("member.") || action.startsWith("environment.access_");
+  return (
+    action.startsWith("member.") || action.startsWith("environment.access_")
+  );
 }
 
 function getActionBadgeClass(action: string): string {
-  if (action.includes("deleted") || action.includes("removed") || action.includes("revoked")) {
+  if (
+    action.includes("deleted") ||
+    action.includes("removed") ||
+    action.includes("revoked")
+  ) {
     return "border-rose-500/25 bg-rose-500/10 text-rose-700 dark:text-rose-300";
   }
-  if (action.includes("updated") || action.includes("read_batch") || action.includes("role_updated")) {
+  if (
+    action.includes("updated") ||
+    action.includes("read_batch") ||
+    action.includes("role_updated")
+  ) {
     return "border-sky-500/25 bg-sky-500/10 text-sky-700 dark:text-sky-300";
   }
-  if (action.includes("created") || action.includes("invited") || action.includes("granted")) {
+  if (
+    action.includes("created") ||
+    action.includes("invited") ||
+    action.includes("granted")
+  ) {
     return "border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
   }
   return "border-muted-foreground/20 bg-muted text-muted-foreground";
@@ -245,7 +268,9 @@ function getDetailSummary(
   changeEntries: Array<[string, AuditLogChange]>,
   keyName?: string,
 ): string | null {
-  const allowedEnvsChange = changeEntries.find(([field]) => field === "allowed_environments");
+  const allowedEnvsChange = changeEntries.find(
+    ([field]) => field === "allowed_environments",
+  );
   if (allowedEnvsChange) {
     return `Allowed Environments: ${formatDiffValue(allowedEnvsChange[1].old)} to ${formatDiffValue(allowedEnvsChange[1].new)}`;
   }
@@ -283,7 +308,9 @@ function getNonDiffContextSummary(
     typeof metadata?.count === "number" && Number.isFinite(metadata.count)
       ? metadata.count
       : null;
-  const environment = metadata?.environment ? String(metadata.environment) : null;
+  const environment = metadata?.environment
+    ? String(metadata.environment)
+    : null;
   const source =
     metadata?.source === "cli"
       ? "CLI"
@@ -299,13 +326,15 @@ function getNonDiffContextSummary(
 
   if (action === "secret.created") {
     if (keyName) return `Created secret key: ${keyName}`;
-    if (count !== null) return `Created ${count} secret(s)${envPart}${sourcePart}`;
+    if (count !== null)
+      return `Created ${count} secret(s)${envPart}${sourcePart}`;
     return `Secret created${envPart}${sourcePart}`;
   }
 
   if (action === "secret.updated") {
     if (keyName) return `Updated secret key: ${keyName}`;
-    if (count !== null) return `Updated ${count} secret(s)${envPart}${sourcePart}`;
+    if (count !== null)
+      return `Updated ${count} secret(s)${envPart}${sourcePart}`;
     return `Secret updated${envPart}${sourcePart}`;
   }
 
@@ -396,7 +425,9 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
           throw new Error("Too many requests. Please wait a moment.");
         }
         if (res.status === 403 || res.status === 401) {
-          throw new Error("You do not have access to this project's audit logs.");
+          throw new Error(
+            "You do not have access to this project's audit logs.",
+          );
         }
         throw new Error("Failed to load audit logs");
       }
@@ -515,9 +546,12 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
           <div className="rounded-full bg-muted p-3 mb-4">
             <AlertCircle className="h-6 w-6 text-muted-foreground" />
           </div>
-          <h3 className="text-lg font-medium text-foreground mb-1">No Audit Logs Found</h3>
+          <h3 className="text-lg font-medium text-foreground mb-1">
+            No Audit Logs Found
+          </h3>
           <p className="text-sm text-muted-foreground max-w-sm">
-            There has been no recorded activity in this project yet. Actions like adding or deleting secrets will appear here.
+            There has been no recorded activity in this project yet. Actions
+            like adding or deleting secrets will appear here.
           </p>
         </div>
       </div>
@@ -533,8 +567,12 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
           <TableHeader>
             <TableRow className="bg-muted/50 hover:bg-muted/50">
               <TableHead className="w-[40px]" />
-              <TableHead className="w-[190px] whitespace-nowrap">Timestamp</TableHead>
-              <TableHead className="w-[170px] whitespace-nowrap">Action</TableHead>
+              <TableHead className="w-[190px] whitespace-nowrap">
+                Timestamp
+              </TableHead>
+              <TableHead className="w-[170px] whitespace-nowrap">
+                Action
+              </TableHead>
               <TableHead className="w-[240px] min-w-[180px]">Actor</TableHead>
               <TableHead className="min-w-[260px]">Details</TableHead>
             </TableRow>
@@ -550,7 +588,11 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
               const effectiveAction = getEffectiveAction(log);
               const actionText = getActionLabel(effectiveAction);
               const detailsSummary =
-                getNonDiffContextSummary(effectiveAction, log.metadata, keyName) ||
+                getNonDiffContextSummary(
+                  effectiveAction,
+                  log.metadata,
+                  keyName,
+                ) ||
                 (!canExpand ? getDetailSummary(changeEntries, keyName) : null);
               const shouldShowAffectedUser =
                 isMemberRelatedAction(effectiveAction) && Boolean(affectedUser);
@@ -562,7 +604,9 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                       {canExpand ? (
                         <button
                           type="button"
-                          aria-label={isExpanded ? "Collapse diff" : "Expand diff"}
+                          aria-label={
+                            isExpanded ? "Collapse diff" : "Expand diff"
+                          }
                           onClick={() => toggleRow(log.id)}
                           className="inline-flex h-7 w-7 items-center justify-center rounded-md hover:bg-muted"
                         >
@@ -575,14 +619,19 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                       ) : null}
                     </TableCell>
                     <TableCell className="text-muted-foreground whitespace-nowrap">
-                      <DateDisplay date={log.created_at} formatType="absolute" />
+                      <DateDisplay
+                        date={log.created_at}
+                        formatType="absolute"
+                      />
                     </TableCell>
                     <TableCell>
                       <Badge
                         variant="secondary"
                         className={`font-mono font-medium text-[10px] uppercase whitespace-nowrap border ${getActionBadgeClass(effectiveAction)}`}
                       >
-                        <span className="mr-1 inline-flex">{getActionIcon(effectiveAction)}</span>
+                        <span className="mr-1 inline-flex">
+                          {getActionIcon(effectiveAction)}
+                        </span>
                         {actionText}
                       </Badge>
                     </TableCell>
@@ -597,9 +646,15 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                           }}
                         />
                         <div className="flex flex-col truncate min-w-0">
-                          <span className="font-medium text-foreground truncate">{log.actor_name || "Former Member"}</span>
+                          <span className="font-medium text-foreground truncate">
+                            {log.actor_name ||
+                              log.actor_email ||
+                              "Former Member"}
+                          </span>
                           {log.actor_email && (
-                            <span className="text-xs text-muted-foreground truncate">{log.actor_email}</span>
+                            <span className="text-xs text-muted-foreground truncate">
+                              {log.actor_email}
+                            </span>
                           )}
                           {log.actor_type === "machine" && (
                             <span className="text-xs text-muted-foreground font-mono truncate">
@@ -613,13 +668,16 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                       <div className="flex flex-col gap-1">
                         {shouldShowAffectedUser && (
                           <span className="inline-flex items-center gap-1">
-                            <UserRound className="h-3.5 w-3.5" /> Affected User: {affectedUser}
+                            <UserRound className="h-3.5 w-3.5" /> Affected User:{" "}
+                            {affectedUser}
                           </span>
                         )}
                         {detailsSummary ? (
                           <span>{detailsSummary}</span>
                         ) : (
-                          <span>{canExpand ? "Expand row to view changes" : "-"}</span>
+                          <span>
+                            {canExpand ? "Expand row to view changes" : "-"}
+                          </span>
                         )}
                       </div>
                     </TableCell>
@@ -630,17 +688,23 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                       <TableCell colSpan={5}>
                         <div className="py-2 pl-10 pr-2 space-y-2">
                           {changeEntries.map(([field, change]) => (
-                            <div key={field} className="text-sm flex flex-wrap items-center gap-2">
+                            <div
+                              key={field}
+                              className="text-sm flex flex-wrap items-center gap-2"
+                            >
                               <span className="font-medium text-foreground">
                                 {formatFieldLabel(field, keyName)}:
                               </span>
-                              {field === "value" && isRedactedPair(change.old, change.new) ? (
+                              {field === "value" &&
+                              isRedactedPair(change.old, change.new) ? (
                                 <span className="inline-flex items-center gap-1 text-muted-foreground font-medium">
                                   Value updated
                                 </span>
                               ) : (
                                 <>
-                                  <span className="text-muted-foreground line-through">{formatDiffValue(change.old)}</span>
+                                  <span className="text-muted-foreground line-through">
+                                    {formatDiffValue(change.old)}
+                                  </span>
                                   <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
                                   <span className="text-foreground font-medium">
                                     {formatDiffValue(change.new)}
@@ -668,8 +732,8 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
           const canExpand = changeEntries.length > 0;
           const isExpanded = expandedRows.has(log.id);
           const affectedUser = getBeneficiaryLabel(log.metadata);
-              const effectiveAction = getEffectiveAction(log);
-              const actionText = getActionLabel(effectiveAction);
+          const effectiveAction = getEffectiveAction(log);
+          const actionText = getActionLabel(effectiveAction);
           const detailsSummary =
             getNonDiffContextSummary(effectiveAction, log.metadata, keyName) ||
             (!canExpand ? getDetailSummary(changeEntries, keyName) : null);
@@ -677,7 +741,10 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
             isMemberRelatedAction(effectiveAction) && Boolean(affectedUser);
 
           return (
-            <div key={log.id} className="p-4 bg-card rounded-xl border shadow-sm flex flex-col gap-3">
+            <div
+              key={log.id}
+              className="p-4 bg-card rounded-xl border shadow-sm flex flex-col gap-3"
+            >
               <div className="flex flex-wrap justify-between items-start gap-2">
                 <div className="flex items-center gap-2">
                   {canExpand ? (
@@ -698,7 +765,9 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                     variant="secondary"
                     className={`font-mono font-medium text-[10px] uppercase border ${getActionBadgeClass(effectiveAction)}`}
                   >
-                    <span className="mr-1 inline-flex">{getActionIcon(effectiveAction)}</span>
+                    <span className="mr-1 inline-flex">
+                      {getActionIcon(effectiveAction)}
+                    </span>
                     {actionText}
                   </Badge>
                 </div>
@@ -717,11 +786,19 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                   }}
                 />
                 <div className="flex flex-col min-w-0">
-                  <span className="font-medium text-sm text-foreground truncate">{log.actor_name || "Former Member"}</span>
+                  <span className="font-medium text-sm text-foreground truncate">
+                    {log.actor_name || log.actor_email || "Former Member"}
+                  </span>
                   <div className="flex items-center gap-2 text-xs truncate">
-                    {log.actor_email && <span className="text-muted-foreground truncate">{log.actor_email}</span>}
+                    {log.actor_email && (
+                      <span className="text-muted-foreground truncate">
+                        {log.actor_email}
+                      </span>
+                    )}
                     {log.actor_type === "machine" && (
-                      <span className="text-muted-foreground font-mono truncate">Service Token</span>
+                      <span className="text-muted-foreground font-mono truncate">
+                        Service Token
+                      </span>
                     )}
                   </div>
                 </div>
@@ -731,26 +808,37 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                 <div className="text-sm text-muted-foreground space-y-1">
                   {shouldShowAffectedUser && (
                     <div className="inline-flex items-center gap-1">
-                      <UserRound className="h-3.5 w-3.5" /> Affected User: {affectedUser}
+                      <UserRound className="h-3.5 w-3.5" /> Affected User:{" "}
+                      {affectedUser}
                     </div>
                   )}
                   {detailsSummary ? <div>{detailsSummary}</div> : null}
-                  {!detailsSummary && canExpand ? <div>Expand row to view changes</div> : null}
+                  {!detailsSummary && canExpand ? (
+                    <div>Expand row to view changes</div>
+                  ) : null}
                 </div>
               )}
 
               {canExpand && isExpanded && (
                 <div className="rounded-lg border bg-muted/20 p-3 space-y-2">
                   {changeEntries.map(([field, change]) => (
-                    <div key={field} className="text-sm flex flex-wrap items-center gap-2">
-                      <span className="font-medium text-foreground">{formatFieldLabel(field, keyName)}:</span>
-                      {field === "value" && isRedactedPair(change.old, change.new) ? (
+                    <div
+                      key={field}
+                      className="text-sm flex flex-wrap items-center gap-2"
+                    >
+                      <span className="font-medium text-foreground">
+                        {formatFieldLabel(field, keyName)}:
+                      </span>
+                      {field === "value" &&
+                      isRedactedPair(change.old, change.new) ? (
                         <span className="inline-flex items-center gap-1 text-muted-foreground font-medium">
                           Value updated
                         </span>
                       ) : (
                         <>
-                          <span className="text-muted-foreground line-through">{formatDiffValue(change.old)}</span>
+                          <span className="text-muted-foreground line-through">
+                            {formatDiffValue(change.old)}
+                          </span>
                           <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
                           <span className="text-foreground font-medium">
                             {formatDiffValue(change.new)}

--- a/src/components/dashboard/share-confirmation-dialog.tsx
+++ b/src/components/dashboard/share-confirmation-dialog.tsx
@@ -1,151 +1,179 @@
 import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
-import { Loader2, Check, X, ArrowRight } from "lucide-react"
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Loader2, Check, X, ArrowRight } from "lucide-react";
 
 export interface PendingChange {
-    userId: string
-    type: 'approve' | 'deny' | 'role_change' | 'revoke'
-    currentRole?: 'owner' | 'viewer' | 'editor' | 'pending'
-    newRole?: 'viewer' | 'editor'
-    email?: string
-    avatar?: string
-    requestId?: string
-    allowedEnvironments?: string[]
+  userId: string;
+  type: "approve" | "deny" | "role_change" | "revoke";
+  currentRole?: "owner" | "viewer" | "editor" | "pending";
+  newRole?: "viewer" | "editor";
+  email?: string;
+  avatar?: string;
+  requestId?: string;
+  allowedEnvironments?: string[];
 }
 
 interface ShareConfirmationDialogProps {
-    open: boolean
-    onOpenChange: (open: boolean) => void
-    changes: PendingChange[]
-    onConfirm: () => Promise<void>
-    loading?: boolean
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  changes: PendingChange[];
+  onConfirm: () => Promise<void>;
+  loading?: boolean;
 }
 
 export function ShareConfirmationDialog({
-    open,
-    onOpenChange,
-    changes,
-    onConfirm,
-    loading = false
+  open,
+  onOpenChange,
+  changes,
+  onConfirm,
+  loading = false,
 }: ShareConfirmationDialogProps) {
-    const approvals = changes.filter(c => c.type === 'approve')
-    const denials = changes.filter(c => c.type === 'deny')
-    const roleChanges = changes.filter(c => c.type === 'role_change')
-    const revocations = changes.filter(c => c.type === 'revoke')
+  const approvals = changes.filter((c) => c.type === "approve");
+  const denials = changes.filter((c) => c.type === "deny");
+  const roleChanges = changes.filter((c) => c.type === "role_change");
+  const revocations = changes.filter((c) => c.type === "revoke");
 
-    return (
-        <AlertDialog open={open} onOpenChange={onOpenChange}>
-            <AlertDialogContent className="w-[calc(100vw-2rem)] sm:max-w-lg max-h-[90vh] overflow-y-auto">
-                <AlertDialogHeader>
-                    <AlertDialogTitle className="text-lg sm:text-xl">Confirm Changes</AlertDialogTitle>
-                    <AlertDialogDescription className="text-sm">
-                        Review and confirm the following changes to project access:
-                    </AlertDialogDescription>
-                </AlertDialogHeader>
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="w-[calc(100vw-2rem)] sm:max-w-lg max-h-[90vh] overflow-y-auto">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-lg sm:text-xl">
+            Confirm Changes
+          </AlertDialogTitle>
+          <AlertDialogDescription className="text-sm">
+            Review and confirm the following changes to project access:
+          </AlertDialogDescription>
+        </AlertDialogHeader>
 
-                <div className="space-y-4 py-4 max-h-[60vh] overflow-y-auto">
-                    {/* Approvals */}
-                    {approvals.length > 0 && (
-                        <div className="space-y-2">
-                            <h4 className="text-sm font-medium flex items-center gap-2">
-                                <Check className="h-4 w-4 text-green-600 shrink-0" />
-                                Approve Access ({approvals.length})
-                            </h4>
-                            <div className="space-y-1 pl-6">
-                                {approvals.map((change) => (
-                                    <p key={change.userId} className="text-sm text-muted-foreground truncate">
-                                        <span className="truncate">{change.email || 'User'}</span> as <span className="font-medium capitalize">{change.newRole || 'viewer'}</span>
-                                    </p>
-                                ))}
-                            </div>
-                        </div>
+        <div className="space-y-4 py-4 max-h-[60vh] overflow-y-auto">
+          {/* Approvals */}
+          {approvals.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="text-sm font-medium flex items-center gap-2">
+                <Check className="h-4 w-4 text-green-600 shrink-0" />
+                Approve Access ({approvals.length})
+              </h4>
+              <div className="space-y-1 pl-6">
+                {approvals.map((change) => (
+                  <p
+                    key={change.userId}
+                    className="text-sm text-muted-foreground truncate"
+                  >
+                    <span className="truncate">{change.email || "User"}</span>{" "}
+                    as{" "}
+                    <span className="font-medium capitalize">
+                      {change.newRole || "viewer"}
+                    </span>
+                  </p>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Denials */}
+          {denials.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="text-sm font-medium flex items-center gap-2">
+                <X className="h-4 w-4 text-red-600" />
+                Deny Access ({denials.length})
+              </h4>
+              <div className="space-y-1 pl-6">
+                {denials.map((change) => (
+                  <p
+                    key={change.userId}
+                    className="text-sm text-muted-foreground"
+                  >
+                    {change.email || "User"}
+                  </p>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Role Changes */}
+          {roleChanges.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="text-sm font-medium flex items-center gap-2">
+                <ArrowRight className="h-4 w-4 text-blue-600" />
+                Change Roles ({roleChanges.length})
+              </h4>
+              <div className="space-y-1 pl-6">
+                {roleChanges.map((change) => (
+                  <p
+                    key={change.userId}
+                    className="text-sm text-muted-foreground"
+                  >
+                    {change.email || "User"}:{" "}
+                    {change.currentRole !== change.newRole ? (
+                      <>
+                        <span className="capitalize">{change.currentRole}</span>
+                        <ArrowRight
+                          className="mx-1 inline-block h-3.5 w-3.5 align-[-1px] text-muted-foreground/80"
+                          aria-hidden="true"
+                        />
+                        <span className="font-medium capitalize">
+                          {change.newRole}
+                        </span>
+                      </>
+                    ) : (
+                      <span className="font-medium capitalize">
+                        {change.currentRole}
+                      </span>
                     )}
-
-                    {/* Denials */}
-                    {denials.length > 0 && (
-                        <div className="space-y-2">
-                            <h4 className="text-sm font-medium flex items-center gap-2">
-                                <X className="h-4 w-4 text-red-600" />
-                                Deny Access ({denials.length})
-                            </h4>
-                            <div className="space-y-1 pl-6">
-                                {denials.map((change) => (
-                                    <p key={change.userId} className="text-sm text-muted-foreground">
-                                        {change.email || 'User'}
-                                    </p>
-                                ))}
-                            </div>
-                        </div>
+                    {change.allowedEnvironments !== undefined && (
+                      <span className="ml-2 text-xs opacity-70 italic">
+                        (env access updated)
+                      </span>
                     )}
+                  </p>
+                ))}
+              </div>
+            </div>
+          )}
 
-                    {/* Role Changes */}
-                    {roleChanges.length > 0 && (
-                        <div className="space-y-2">
-                            <h4 className="text-sm font-medium flex items-center gap-2">
-                                <ArrowRight className="h-4 w-4 text-blue-600" />
-                                Change Roles ({roleChanges.length})
-                            </h4>
-                            <div className="space-y-1 pl-6">
-                                {roleChanges.map((change) => (
-                                    <p key={change.userId} className="text-sm text-muted-foreground">
-                                        {change.email || 'User'}:{' '}
-                                        {change.currentRole !== change.newRole ? (
-                                            <>
-                                                <span className="capitalize">{change.currentRole}</span> →{' '}
-                                                <span className="font-medium capitalize">{change.newRole}</span>
-                                            </>
-                                        ) : (
-                                            <span className="font-medium capitalize">{change.currentRole}</span>
-                                        )}
-                                        {change.allowedEnvironments !== undefined && (
-                                            <span className="ml-2 text-xs opacity-70 italic">(env access updated)</span>
-                                        )}
-                                    </p>
-                                ))}
-                            </div>
-                        </div>
-                    )}
+          {/* Revocations */}
+          {revocations.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="text-sm font-medium flex items-center gap-2">
+                <X className="h-4 w-4 text-destructive" />
+                Revoke Access ({revocations.length})
+              </h4>
+              <div className="space-y-1 pl-6">
+                {revocations.map((change) => (
+                  <p
+                    key={change.userId}
+                    className="text-sm text-muted-foreground"
+                  >
+                    {change.email || "User"}
+                  </p>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
 
-                    {/* Revocations */}
-                    {revocations.length > 0 && (
-                        <div className="space-y-2">
-                            <h4 className="text-sm font-medium flex items-center gap-2">
-                                <X className="h-4 w-4 text-destructive" />
-                                Revoke Access ({revocations.length})
-                            </h4>
-                            <div className="space-y-1 pl-6">
-                                {revocations.map((change) => (
-                                    <p key={change.userId} className="text-sm text-muted-foreground">
-                                        {change.email || 'User'}
-                                    </p>
-                                ))}
-                            </div>
-                        </div>
-                    )}
-                </div>
-
-                <AlertDialogFooter>
-                    <AlertDialogCancel disabled={loading}>Cancel</AlertDialogCancel>
-                    <AlertDialogAction onClick={onConfirm} disabled={loading}>
-                        {loading ? (
-                            <>
-                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                                Applying...
-                            </>
-                        ) : (
-                            'Confirm'
-                        )}
-                    </AlertDialogAction>
-                </AlertDialogFooter>
-            </AlertDialogContent>
-        </AlertDialog>
-    )
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={loading}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm} disabled={loading}>
+            {loading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Applying...
+              </>
+            ) : (
+              "Confirm"
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
 }

--- a/src/components/dashboard/share-project-dialog.tsx
+++ b/src/components/dashboard/share-project-dialog.tsx
@@ -375,7 +375,7 @@ export function ShareProjectDialog({
           case "approve": {
             const res = await approveRequest(
               change.requestId!,
-              "viewer",
+                change.newRole || "viewer",
               true,
               change.allowedEnvironments
             );

--- a/src/components/editor/env-var-table.tsx
+++ b/src/components/editor/env-var-table.tsx
@@ -255,7 +255,8 @@ export function EnvVarTable({
                                     user={{
                                       email: variable.userInfo.updater.email,
                                       avatar: variable.userInfo.updater.avatar,
-                                      username: variable.userInfo.updater.username,
+                                      username:
+                                        variable.userInfo.updater.username,
                                       name:
                                         variable.userInfo.updater.username ||
                                         variable.userInfo.updater.email,
@@ -351,7 +352,7 @@ export function EnvVarTable({
                                       </span>
                                     </>
                                   ) : (
-                                    <span>User Left</span>
+                                    <span>Former Member</span>
                                   )}
                                 </div>
                               </div>

--- a/src/components/settings/settings-view.tsx
+++ b/src/components/settings/settings-view.tsx
@@ -188,9 +188,7 @@ export default function SettingsView() {
     /[.*+?^${}()|[\]\\]/g,
     "\\$&",
   );
-  const defaultUsernameRegex = new RegExp(
-    `^${escapedDefaultBase}(-\\d+)?$`,
-  );
+  const defaultUsernameRegex = new RegExp(`^${escapedDefaultBase}(-\\d+)?$`);
   const hasCustomizedUsername = user?.username
     ? !defaultUsernameRegex.test(user.username)
     : false;
@@ -556,6 +554,17 @@ export default function SettingsView() {
           </AlertDialogHeader>
 
           <div className="py-4 space-y-4">
+            {isDeletingAccount && (
+              <div className="p-3 border rounded-md bg-muted/50 text-sm text-muted-foreground flex items-start gap-2">
+                <Loader2 className="h-4 w-4 animate-spin mt-0.5 shrink-0" />
+                <p>
+                  Deletion is in progress. We are safely transferring any shared
+                  project secrets you created to the project owners and
+                  preserving audit history before removing your account.
+                </p>
+              </div>
+            )}
+
             {projects.length > 0 && (
               <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-md space-y-3">
                 <p className="text-sm font-medium text-destructive">
@@ -627,7 +636,7 @@ export default function SettingsView() {
               {isDeletingAccount ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin" />
-                  Deleting...
+                  Transferring data and deleting...
                 </>
               ) : (
                 "Delete Account"

--- a/src/components/ui/user-avatar.tsx
+++ b/src/components/ui/user-avatar.tsx
@@ -31,17 +31,41 @@ export function UserAvatar({
   fallbackType: _fallbackType = "dicebear",
   ...props
 }: UserAvatarProps) {
+  const proxiedAvatar = React.useMemo(() => {
+    if (!propAvatar && !user?.avatar) return "";
+
+    const rawAvatar = propAvatar || user?.avatar || "";
+    if (!rawAvatar) return "";
+
+    // Keep internal assets and already-proxied URLs untouched.
+    if (
+      rawAvatar.startsWith("/") ||
+      rawAvatar.startsWith("data:") ||
+      rawAvatar.startsWith("blob:") ||
+      rawAvatar.startsWith("/api/avatar?")
+    ) {
+      return rawAvatar;
+    }
+
+    try {
+      const parsed = new URL(rawAvatar);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        return rawAvatar;
+      }
+
+      return `/api/avatar?url=${encodeURIComponent(rawAvatar)}`;
+    } catch {
+      return rawAvatar;
+    }
+  }, [propAvatar, user?.avatar]);
+
   // Determine the values to use
   const email = propEmail || user?.email || "";
-  const avatar = propAvatar || user?.avatar || "";
+  const avatar = proxiedAvatar;
 
   // Use username if available, otherwise email for display name
   const displayName =
-    user?.username ||
-    user?.name ||
-    user?.firstName ||
-    email ||
-    "User";
+    user?.username || user?.name || user?.firstName || email || "User";
   const initials =
     displayName
       .trim()

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -56,3 +56,11 @@ export const auditWriteRateLimit = new Ratelimit({
   analytics: true,
   prefix: "@upstash/ratelimit/audit_write",
 });
+
+// Avatar proxy: generous read limit to protect upstream providers from burst fetches
+export const avatarProxyRateLimit = new Ratelimit({
+  redis: getRedisClient(),
+  limiter: Ratelimit.slidingWindow(20, "1 m"),
+  analytics: true,
+  prefix: "@upstash/ratelimit/avatar_proxy",
+});

--- a/src/lib/username.ts
+++ b/src/lib/username.ts
@@ -15,14 +15,12 @@ export function inferUsernameFromAuth(
   const meta = metadata || {};
   const candidates = [
     typeof meta.username === "string" ? meta.username : "",
-    typeof meta.preferred_username === "string"
-      ? meta.preferred_username
-      : "",
+    typeof meta.preferred_username === "string" ? meta.preferred_username : "",
     typeof meta.user_name === "string" ? meta.user_name : "",
     typeof meta.login === "string" ? meta.login : "",
+    email ? email.split("@")[0] : "",
     typeof meta.name === "string" ? meta.name : "",
     typeof meta.full_name === "string" ? meta.full_name : "",
-    email ? email.split("@")[0] : "",
   ];
 
   for (const candidate of candidates) {

--- a/supabase/migrations/20260316103000_prepare_user_account_deletion.sql
+++ b/supabase/migrations/20260316103000_prepare_user_account_deletion.sql
@@ -1,0 +1,134 @@
+-- Preserve shared project data when an account is deleted.
+-- 1) Reassign secrets authored by the deleting user to each project's owner.
+-- 2) Reassign project_members.added_by references to each project's owner.
+-- 3) Snapshot actor identity inside audit_logs.metadata to keep historical attribution.
+-- 4) Ensure audit_logs.actor_id never has a hard FK to auth.users.
+
+create or replace function public.prepare_user_account_deletion(
+  p_user_id uuid,
+  p_actor_name text default null,
+  p_actor_email text default null
+)
+returns table (
+  reassigned_secrets bigint,
+  nulled_last_updated_by bigint,
+  reassigned_added_by bigint,
+  updated_audit_logs bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_reassigned_secrets bigint := 0;
+  v_nulled_last_updated_by bigint := 0;
+  v_reassigned_added_by bigint := 0;
+  v_updated_audit_logs bigint := 0;
+begin
+  if p_user_id is null then
+    raise exception 'p_user_id is required';
+  end if;
+
+  -- Reassign secrets in shared projects to each project's owner.
+  with reassigned as (
+    update public.secrets s
+    set user_id = p.user_id
+    from public.projects p
+    where s.project_id = p.id
+      and s.user_id = p_user_id
+      and p.user_id <> p_user_id
+    returning s.id
+  )
+  select count(*) into v_reassigned_secrets from reassigned;
+
+  -- If this user was the last updater, null the pointer.
+  update public.secrets
+  set last_updated_by = null
+  where last_updated_by = p_user_id;
+  get diagnostics v_nulled_last_updated_by = row_count;
+
+  -- Preserve project memberships created by this user in shared projects.
+  with reassigned_members as (
+    update public.project_members pm
+    set added_by = p.user_id
+    from public.projects p
+    where pm.project_id = p.id
+      and pm.added_by = p_user_id
+      and p.user_id <> p_user_id
+    returning pm.id
+  )
+  select count(*) into v_reassigned_added_by from reassigned_members;
+
+  -- Preserve actor identity even after auth user deletion.
+  update public.audit_logs al
+  set metadata = jsonb_set(
+    jsonb_set(
+      coalesce(al.metadata, '{}'::jsonb),
+      '{actor_name}',
+      to_jsonb(
+        coalesce(
+          nullif(al.metadata ->> 'actor_name', ''),
+          nullif(p_actor_name, ''),
+          nullif(split_part(coalesce(p_actor_email, ''), '@', 1), ''),
+          concat('user-', left(p_user_id::text, 8))
+        )
+      ),
+      true
+    ),
+    '{actor_email}',
+    to_jsonb(
+      coalesce(
+        nullif(al.metadata ->> 'actor_email', ''),
+        nullif(p_actor_email, ''),
+        ''
+      )
+    ),
+    true
+  )
+  where al.actor_type = 'user'
+    and al.actor_id = p_user_id;
+  get diagnostics v_updated_audit_logs = row_count;
+
+  return query
+  select
+    v_reassigned_secrets,
+    v_nulled_last_updated_by,
+    v_reassigned_added_by,
+    v_updated_audit_logs;
+end;
+$$;
+
+revoke all on function public.prepare_user_account_deletion(uuid, text, text) from public;
+revoke all on function public.prepare_user_account_deletion(uuid, text, text) from anon;
+revoke all on function public.prepare_user_account_deletion(uuid, text, text) from authenticated;
+grant execute on function public.prepare_user_account_deletion(uuid, text, text) to service_role;
+
+-- Defensive guard: keep actor_id as a non-FK UUID so auth user deletion never removes audit logs.
+do $$
+declare
+  fk record;
+begin
+  for fk in
+    select con.conname
+    from pg_constraint con
+    join pg_class rel on rel.oid = con.conrelid
+    join pg_namespace nsp on nsp.oid = rel.relnamespace
+    where nsp.nspname = 'public'
+      and rel.relname = 'audit_logs'
+      and con.contype = 'f'
+      and con.conkey = array[(
+        select attnum
+        from pg_attribute
+        where attrelid = rel.oid
+          and attname = 'actor_id'
+          and not attisdropped
+        limit 1
+      )]
+  loop
+    execute format('alter table public.audit_logs drop constraint if exists %I', fk.conname);
+  end loop;
+end
+$$;
+
+comment on column public.audit_logs.actor_id is
+  'Identifier of acting principal. Intentionally no FK to auth.users so audit history survives account deletion.';

--- a/supabase/migrations/20260316114000_fix_simple_mode_member_environment_access.sql
+++ b/supabase/migrations/20260316114000_fix_simple_mode_member_environment_access.sql
@@ -1,0 +1,9 @@
+-- In simple mode, environment restrictions should not be persisted.
+-- Normalize all simple-mode memberships to unrestricted access.
+
+update public.project_members pm
+set allowed_environments = null
+from public.projects p
+where pm.project_id = p.id
+  and coalesce(p.ui_mode, 'simple') = 'simple'
+  and pm.allowed_environments is not null;

--- a/supabase/migrations/20260316122000_prefer_email_local_for_default_username.sql
+++ b/supabase/migrations/20260316122000_prefer_email_local_for_default_username.sql
@@ -1,0 +1,80 @@
+-- Align DB-side default username inference with app behavior.
+-- Prefer stable handle-like sources first, then email local-part,
+-- and only then free-form display names.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user_profile()
+RETURNS TRIGGER AS $$
+DECLARE
+  extracted_username TEXT;
+  base_username TEXT;
+  suffix INTEGER := 1;
+BEGIN
+  extracted_username := COALESCE(
+    NULLIF(TRIM(NEW.raw_user_meta_data->>'username'), ''),
+    NULLIF(TRIM(NEW.raw_user_meta_data->>'preferred_username'), ''),
+    NULLIF(TRIM(NEW.raw_user_meta_data->>'user_name'), ''),
+    NULLIF(TRIM(NEW.raw_user_meta_data->>'login'), ''),
+    NULLIF(TRIM(SPLIT_PART(COALESCE(NEW.email, ''), '@', 1)), ''),
+    NULLIF(TRIM(NEW.raw_user_meta_data->>'name'), ''),
+    NULLIF(TRIM(NEW.raw_user_meta_data->>'full_name'), ''),
+    'user'
+  );
+
+  base_username := LOWER(
+    REGEXP_REPLACE(extracted_username, '[^a-zA-Z0-9_-]+', '-', 'g')
+  );
+  base_username := REGEXP_REPLACE(base_username, '^[-_]+|[-_]+$', '', 'g');
+  IF base_username IS NULL OR base_username = '' THEN
+    base_username := 'user';
+  END IF;
+
+  extracted_username := base_username;
+
+  WHILE EXISTS (
+    SELECT 1
+    FROM public.profiles p
+    WHERE LOWER(p.username) = LOWER(extracted_username)
+      AND p.id <> NEW.id
+  ) LOOP
+    extracted_username := base_username || '-' || suffix;
+    suffix := suffix + 1;
+  END LOOP;
+
+  INSERT INTO public.profiles (id, username, avatar_url)
+  VALUES (
+    NEW.id,
+    extracted_username,
+    NEW.raw_user_meta_data->>'avatar_url'
+  )
+  ON CONFLICT (id) DO UPDATE SET
+    username = CASE
+      WHEN public.profiles.username IS NULL OR public.profiles.username = ''
+        THEN EXCLUDED.username
+      ELSE public.profiles.username
+    END,
+    avatar_url = COALESCE(EXCLUDED.avatar_url, public.profiles.avatar_url),
+    updated_at = NOW();
+
+  INSERT INTO public.notification_preferences (
+    user_id,
+    email_access_requests, email_access_granted,
+    email_device_activity, email_security_alerts,
+    email_project_activity, email_cli_activity, email_system_updates,
+    app_access_requests,  app_access_granted,
+    app_device_activity,  app_security_alerts,
+    app_project_activity, app_cli_activity, app_system_updates,
+    digest_frequency
+  ) VALUES (
+    NEW.id,
+    TRUE,  TRUE,
+    TRUE,  FALSE,
+    FALSE, FALSE, FALSE,
+    TRUE,  TRUE,
+    TRUE,  TRUE,
+    TRUE,  TRUE, TRUE,
+    'none'
+  ) ON CONFLICT (user_id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;

--- a/supabase/migrations/20260316124000_update_account_deletion_audit_identity.sql
+++ b/supabase/migrations/20260316124000_update_account_deletion_audit_identity.sql
@@ -1,0 +1,96 @@
+-- Ensure account deletion audit snapshots use stable, disambiguating fallback labels.
+
+create or replace function public.prepare_user_account_deletion(
+  p_user_id uuid,
+  p_actor_name text default null,
+  p_actor_email text default null
+)
+returns table (
+  reassigned_secrets bigint,
+  nulled_last_updated_by bigint,
+  reassigned_added_by bigint,
+  updated_audit_logs bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_reassigned_secrets bigint := 0;
+  v_nulled_last_updated_by bigint := 0;
+  v_reassigned_added_by bigint := 0;
+  v_updated_audit_logs bigint := 0;
+begin
+  if p_user_id is null then
+    raise exception 'p_user_id is required';
+  end if;
+
+  with reassigned as (
+    update public.secrets s
+    set user_id = p.user_id
+    from public.projects p
+    where s.project_id = p.id
+      and s.user_id = p_user_id
+      and p.user_id <> p_user_id
+    returning s.id
+  )
+  select count(*) into v_reassigned_secrets from reassigned;
+
+  update public.secrets
+  set last_updated_by = null
+  where last_updated_by = p_user_id;
+  get diagnostics v_nulled_last_updated_by = row_count;
+
+  with reassigned_members as (
+    update public.project_members pm
+    set added_by = p.user_id
+    from public.projects p
+    where pm.project_id = p.id
+      and pm.added_by = p_user_id
+      and p.user_id <> p_user_id
+    returning pm.id
+  )
+  select count(*) into v_reassigned_added_by from reassigned_members;
+
+  update public.audit_logs al
+  set metadata = jsonb_set(
+    jsonb_set(
+      coalesce(al.metadata, '{}'::jsonb),
+      '{actor_name}',
+      to_jsonb(
+        coalesce(
+          nullif(al.metadata ->> 'actor_name', ''),
+          nullif(p_actor_name, ''),
+          nullif(split_part(coalesce(p_actor_email, ''), '@', 1), ''),
+          concat('user-', left(p_user_id::text, 8))
+        )
+      ),
+      true
+    ),
+    '{actor_email}',
+    to_jsonb(
+      coalesce(
+        nullif(al.metadata ->> 'actor_email', ''),
+        nullif(p_actor_email, ''),
+        ''
+      )
+    ),
+    true
+  )
+  where al.actor_type = 'user'
+    and al.actor_id = p_user_id;
+  get diagnostics v_updated_audit_logs = row_count;
+
+  return query
+  select
+    v_reassigned_secrets,
+    v_nulled_last_updated_by,
+    v_reassigned_added_by,
+    v_updated_audit_logs;
+end;
+$$;
+
+revoke all on function public.prepare_user_account_deletion(uuid, text, text) from public;
+revoke all on function public.prepare_user_account_deletion(uuid, text, text) from anon;
+revoke all on function public.prepare_user_account_deletion(uuid, text, text) from authenticated;
+grant execute on function public.prepare_user_account_deletion(uuid, text, text) to service_role;

--- a/supabase/migrations/20260316130000_snapshot_user_identity_on_linked_records.sql
+++ b/supabase/migrations/20260316130000_snapshot_user_identity_on_linked_records.sql
@@ -1,0 +1,200 @@
+-- Persist user identity snapshots on user-linked records before account deletion,
+-- so project/audit UX can still distinguish departed users.
+
+alter table public.secrets
+  add column if not exists created_by_user_id_snapshot uuid,
+  add column if not exists created_by_name text,
+  add column if not exists created_by_email text,
+  add column if not exists last_updated_by_user_id_snapshot uuid,
+  add column if not exists last_updated_by_name text,
+  add column if not exists last_updated_by_email text;
+
+-- Backfill creator snapshots for existing rows.
+update public.secrets s
+set
+  created_by_user_id_snapshot = coalesce(s.created_by_user_id_snapshot, s.user_id),
+  created_by_name = coalesce(
+    s.created_by_name,
+    p.username,
+    split_part(coalesce(u.email, ''), '@', 1),
+    concat('user-', left(coalesce(s.created_by_user_id_snapshot, s.user_id)::text, 8))
+  ),
+  created_by_email = coalesce(s.created_by_email, u.email, '')
+from auth.users u
+left join public.profiles p on p.id = u.id
+where u.id = s.user_id
+  and (
+    s.created_by_user_id_snapshot is null
+    or s.created_by_name is null
+    or s.created_by_email is null
+  );
+
+-- Final creator fallback when auth row is not available.
+update public.secrets s
+set
+  created_by_user_id_snapshot = coalesce(s.created_by_user_id_snapshot, s.user_id),
+  created_by_name = coalesce(
+    s.created_by_name,
+    split_part(coalesce(s.created_by_email, ''), '@', 1),
+    concat('user-', left(coalesce(s.created_by_user_id_snapshot, s.user_id)::text, 8))
+  ),
+  created_by_email = coalesce(s.created_by_email, '')
+where s.created_by_user_id_snapshot is null
+   or s.created_by_name is null
+   or s.created_by_email is null;
+
+-- Backfill updater snapshots for existing rows.
+update public.secrets s
+set
+  last_updated_by_user_id_snapshot = coalesce(s.last_updated_by_user_id_snapshot, s.last_updated_by),
+  last_updated_by_name = coalesce(
+    s.last_updated_by_name,
+    p.username,
+    split_part(coalesce(u.email, ''), '@', 1),
+    concat('user-', left(coalesce(s.last_updated_by_user_id_snapshot, s.last_updated_by)::text, 8))
+  ),
+  last_updated_by_email = coalesce(s.last_updated_by_email, u.email, '')
+from auth.users u
+left join public.profiles p on p.id = u.id
+where s.last_updated_by is not null
+  and u.id = s.last_updated_by
+  and (
+    s.last_updated_by_user_id_snapshot is null
+    or s.last_updated_by_name is null
+    or s.last_updated_by_email is null
+  );
+
+-- Final updater fallback when auth row is not available.
+update public.secrets s
+set
+  last_updated_by_user_id_snapshot = coalesce(s.last_updated_by_user_id_snapshot, s.last_updated_by),
+  last_updated_by_name = coalesce(
+    s.last_updated_by_name,
+    split_part(coalesce(s.last_updated_by_email, ''), '@', 1),
+    concat('user-', left(coalesce(s.last_updated_by_user_id_snapshot, s.last_updated_by)::text, 8))
+  ),
+  last_updated_by_email = coalesce(s.last_updated_by_email, '')
+where s.last_updated_by is not null
+  and (
+    s.last_updated_by_user_id_snapshot is null
+    or s.last_updated_by_name is null
+    or s.last_updated_by_email is null
+  );
+
+create or replace function public.prepare_user_account_deletion(
+  p_user_id uuid,
+  p_actor_name text default null,
+  p_actor_email text default null
+)
+returns table (
+  reassigned_secrets bigint,
+  nulled_last_updated_by bigint,
+  reassigned_added_by bigint,
+  updated_audit_logs bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_reassigned_secrets bigint := 0;
+  v_nulled_last_updated_by bigint := 0;
+  v_reassigned_added_by bigint := 0;
+  v_updated_audit_logs bigint := 0;
+  v_effective_name text;
+  v_effective_email text;
+begin
+  if p_user_id is null then
+    raise exception 'p_user_id is required';
+  end if;
+
+  v_effective_email := coalesce(nullif(p_actor_email, ''), '');
+  v_effective_name := coalesce(
+    nullif(p_actor_name, ''),
+    nullif(split_part(v_effective_email, '@', 1), ''),
+    concat('user-', left(p_user_id::text, 8))
+  );
+
+  -- Snapshot creator identity before ownership reassignment.
+  update public.secrets s
+  set
+    created_by_user_id_snapshot = coalesce(s.created_by_user_id_snapshot, p_user_id),
+    created_by_name = coalesce(s.created_by_name, v_effective_name),
+    created_by_email = coalesce(s.created_by_email, v_effective_email)
+  where s.user_id = p_user_id;
+
+  -- Snapshot updater identity before nulling updater reference.
+  update public.secrets s
+  set
+    last_updated_by_user_id_snapshot = coalesce(s.last_updated_by_user_id_snapshot, p_user_id),
+    last_updated_by_name = coalesce(s.last_updated_by_name, v_effective_name),
+    last_updated_by_email = coalesce(s.last_updated_by_email, v_effective_email)
+  where s.last_updated_by = p_user_id;
+
+  with reassigned as (
+    update public.secrets s
+    set user_id = p.user_id
+    from public.projects p
+    where s.project_id = p.id
+      and s.user_id = p_user_id
+      and p.user_id <> p_user_id
+    returning s.id
+  )
+  select count(*) into v_reassigned_secrets from reassigned;
+
+  update public.secrets
+  set last_updated_by = null
+  where last_updated_by = p_user_id;
+  get diagnostics v_nulled_last_updated_by = row_count;
+
+  with reassigned_members as (
+    update public.project_members pm
+    set added_by = p.user_id
+    from public.projects p
+    where pm.project_id = p.id
+      and pm.added_by = p_user_id
+      and p.user_id <> p_user_id
+    returning pm.id
+  )
+  select count(*) into v_reassigned_added_by from reassigned_members;
+
+  update public.audit_logs al
+  set metadata = jsonb_set(
+    jsonb_set(
+      coalesce(al.metadata, '{}'::jsonb),
+      '{actor_name}',
+      to_jsonb(
+        coalesce(
+          nullif(al.metadata ->> 'actor_name', ''),
+          v_effective_name
+        )
+      ),
+      true
+    ),
+    '{actor_email}',
+    to_jsonb(
+      coalesce(
+        nullif(al.metadata ->> 'actor_email', ''),
+        v_effective_email,
+        ''
+      )
+    ),
+    true
+  )
+  where al.actor_type = 'user'
+    and al.actor_id = p_user_id;
+  get diagnostics v_updated_audit_logs = row_count;
+
+  return query
+  select
+    v_reassigned_secrets,
+    v_nulled_last_updated_by,
+    v_reassigned_added_by,
+    v_updated_audit_logs;
+end;
+$$;
+
+revoke all on function public.prepare_user_account_deletion(uuid, text, text) from public;
+revoke all on function public.prepare_user_account_deletion(uuid, text, text) from anon;
+revoke all on function public.prepare_user_account_deletion(uuid, text, text) from authenticated;
+grant execute on function public.prepare_user_account_deletion(uuid, text, text) to service_role;


### PR DESCRIPTION
Summary\n- Preserve shared secrets and identity metadata across account deletion\n- Fix share approval role propagation and simple-mode access behavior\n- Keep dashboard card activity in sync with editor updates\n\nTesting\n- Local app run via npm run dev\n- Type/diagnostic checks on touched files\n\nCo-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>