### PR TITLE
docs(changelog): capture account lifecycle and identity retention updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ All notable changes to Envault are documented here.
 
 ---
 
+## 1.3.3 — 2026-03-16
+
+> Authors: Dinanath Dash (DinanathDash), Rajat Patra (RawJat)
+### Improvements
+
+- **Account Deletion Data Preservation:** Shared secrets are now preserved during account deletion and reassigned safely to the project owner instead of being removed.
+- **Identity Continuity After Member Exit:** Secret records now retain creator/updater identity snapshots so audit logs and variable tables remain attributable even after a user account is deleted.
+- **Approval + Access Consistency:** Fixed role assignment during share-request approval so the selected role is applied correctly, with environment access handling aligned for simple and advanced project modes.
+- **Project Activity Freshness:** Project dashboard cards now track latest project activity updates from editor/owner secret mutations, with broader cache invalidation to reduce stale timestamps.
+
+---
+
 ## 1.3.2 — 2026-03-16
 
 > Authors: Dinanath Dash (DinanathDash), Rajat Patra (RawJat)

--- a/content/docs/core/access-control.mdx
+++ b/content/docs/core/access-control.mdx
@@ -74,6 +74,16 @@ Every action taken by a user is logged. Owners can view the **Audit Logs** in th
 
 This visibility enables collaborative teams to maintain security awareness and accountability across all project activities.
 
+## Account Deletion Behavior
+
+When a member deletes their account, Envault preserves project integrity and attribution context:
+
+- **Shared secrets are not deleted** during account removal.
+- **Ownership pointers are safely reassigned** to the project owner where required.
+- **Creator/updater identity snapshots are retained** on secret records so project history remains understandable in variable tables and audit timelines.
+
+If a live user profile can no longer be resolved, UI surfaces a fallback identity label while preserving available metadata from prior snapshots.
+
 ## Just-in-Time (JIT) Access via GitHub
 
 When a project is linked to a GitHub repository, Envault can automatically grant **Viewer** access to developers the moment they run `envault pull` - no manual invite or owner approval needed.

--- a/content/docs/core/security.mdx
+++ b/content/docs/core/security.mdx
@@ -31,6 +31,14 @@ Envault supports key rotation for Data Keys. This limits the "blast radius" if a
 - **Immutable Audit Logs**: All administrative actions (mutating secrets, batch reads by machines, project changes) are written to an append-only, immutable `audit_logs` table. Only Project Owners can query this table via strict RLS policies.
 - **Data Retention**: Audit logs undergo automated cleanup and are strictly retained for a maximum of 7 days to balance visibility with privacy considerations.
 
+### Identity Snapshot Retention
+
+For operational continuity, Envault snapshots contributor identity metadata on user-linked secret records.
+
+- Secret creator/updater identity is retained even if the original auth/profile row later disappears.
+- Account deletion flows preserve shared data and keep attribution readable via stored metadata snapshots.
+- Fallback labels are only used when both live identity lookup and stored snapshot metadata are unavailable.
+
 ## Authentication Security
 
 - **Passkeys (WebAuthn)**: Envault supports passwordless authentication using WebAuthn. This provides phishing-resistant, biometric login capabilities and significantly improves account security compared to traditional passwords.


### PR DESCRIPTION
## Summary
- Update changelog Unreleased notes to reflect recent account lifecycle and identity continuity work.
- Document account deletion behavior in RBAC docs, including non-destructive reassignment and metadata continuity.
- Extend security docs with identity snapshot retention semantics for deleted-member attribution.

## Why
- Keep product documentation aligned with shipped behavior after the latest lifecycle fixes.
- Reduce ambiguity around how attribution behaves when users leave or delete accounts.

## Validation
- Confirmed markdown structure and readability.
- Lint status previously clean in local workspace.

Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>