### PR TITLE
feat: secure project ownership transfer handshake with audit + notifications

### DIFF
--- a/content/docs/api/overview.mdx
+++ b/content/docs/api/overview.mdx
@@ -53,6 +53,20 @@ If you exceed these limits, you will receive a `429 Too Many Requests` response.
 
 ## Endpoints
 
+### Ownership Transfer (Project Settings/API)
+
+These endpoints support the ownership transfer handshake:
+
+- `POST /api/projects/:id/transfer/initiate`
+- `POST /api/projects/:id/transfer/accept`
+- `POST /api/projects/:id/transfer/reject`
+
+Notes:
+- `initiate` is owner-only.
+- `accept` / `reject` are target-user-only.
+- Overlapping pending requests per project are blocked.
+- Requests expire after 48 hours.
+
 ### Get Project Secrets
 
 Retrieve all decrypted secrets for a specific project environment.

--- a/content/docs/core/access-control.mdx
+++ b/content/docs/core/access-control.mdx
@@ -27,6 +27,22 @@ The **Owner** has the keys to the castle.
 - **Rotate Keys**: Perform cryptographic key rotation.
 - **Billing**: Manage subscription (if applicable).
 
+### Ownership Transfer Handshake
+
+Project ownership transfer in Envault is a strict two-step handshake to prevent
+forced liability transfer:
+
+1. Current owner initiates a transfer request for a specific target user.
+2. Target user explicitly accepts or rejects the request.
+3. If accepted, Envault executes owner promotion + prior-owner demotion/removal + secret liability reassignment in one transaction.
+
+Transfer requests expire automatically after **48 hours** if not accepted.
+
+<Callout type="warn">
+  Ownership never changes on initiate. The target user must explicitly accept
+  for transfer to complete.
+</Callout>
+
 ### Editor
 
 The **Editor** is the standard role for day-to-day development.

--- a/content/docs/core/projects.mdx
+++ b/content/docs/core/projects.mdx
@@ -36,3 +36,16 @@ Envault implements a Role-Based Access Control (RBAC) system.
 ## Sharing Projects
 
 You can invite team members to your project via email. They will receive an invitation link to join.
+
+## Transfer Ownership
+
+Owners can initiate transfer from the project settings dropdown using
+**Transfer Ownership**.
+
+- Transfers are **pending** until the target user accepts.
+- Target users can reject requests without ownership changes.
+- Pending transfer requests expire after **48 hours**.
+- During acceptance, Envault performs ownership promotion/demotion and secret
+  liability reassignment atomically to avoid partial permission states.
+- In delete confirmation dialogs, owners also get a quick
+  **Transfer ownership instead** action to avoid accidental project deletion.

--- a/content/docs/core/security.mdx
+++ b/content/docs/core/security.mdx
@@ -29,6 +29,7 @@ Envault supports key rotation for Data Keys. This limits the "blast radius" if a
 
 - **RLS (Row Level Security)**: We use Supabase RLS to ensure that users can only access data rows they are explicitly permitted to see. Even if the application logic fails, the database layer attempts to prevent unauthorized access.
 - **Immutable Audit Logs**: All administrative actions (mutating secrets, batch reads by machines, project changes) are written to an append-only, immutable `audit_logs` table. Only Project Owners can query this table via strict RLS policies.
+- **Ownership Chain of Custody**: Ownership transfer emits explicit `TRANSFER_REQUESTED`, `TRANSFER_ACCEPTED`, and `TRANSFER_REJECTED` audit events to preserve legal and operational accountability.
 - **Data Retention**: Audit logs undergo automated cleanup and are strictly retained for a maximum of 7 days to balance visibility with privacy considerations.
 
 ### Identity Snapshot Retention

--- a/src/app/api/project/[projectId]/audit-logs/route.ts
+++ b/src/app/api/project/[projectId]/audit-logs/route.ts
@@ -12,6 +12,9 @@ const ALLOWED_AUDIT_ACTIONS = new Set([
   "member.invited",
   "member.role_updated",
   "member.removed",
+  "transfer.requested",
+  "transfer.accepted",
+  "transfer.rejected",
   "environment.access_updated",
   "environment.access_granted",
   "environment.access_revoked",
@@ -205,18 +208,23 @@ export async function GET(
 
     const beneficiaryUserIds = Array.from(
       new Set(
-        (logs || [])
-          .map((log) => {
+        (logs || []).flatMap((log) => {
             const metadata =
               log.metadata && typeof log.metadata === "object"
                 ? (log.metadata as Record<string, unknown>)
                 : {};
 
-            return (
-              parseMaybeUuid(metadata.member_user_id) ||
-              parseMaybeUuid(metadata.beneficiary_user_id) ||
-              parseMaybeUuid(log.target_resource_id)
-            );
+            const ids = [
+              parseMaybeUuid(metadata.member_user_id),
+              parseMaybeUuid(metadata.beneficiary_user_id),
+              parseMaybeUuid(metadata.previous_owner_id),
+              parseMaybeUuid(metadata.new_owner_id),
+              parseMaybeUuid(metadata.target_user_id),
+              parseMaybeUuid(metadata.rejected_by_user_id),
+              parseMaybeUuid(log.target_resource_id),
+            ];
+
+            return ids.filter((value): value is string => Boolean(value));
           })
           .filter((value): value is string => Boolean(value)),
       ),
@@ -343,6 +351,67 @@ export async function GET(
           userEmailById.get(beneficiaryUserId) ||
           existingBeneficiaryEmail ||
           "";
+      }
+
+      const transferUserMappings: Array<{
+        idKey:
+          | "previous_owner_id"
+          | "new_owner_id"
+          | "target_user_id"
+          | "rejected_by_user_id";
+        nameKey:
+          | "previous_owner_name"
+          | "new_owner_name"
+          | "target_name"
+          | "rejected_by_name";
+        emailKey:
+          | "previous_owner_email"
+          | "new_owner_email"
+          | "target_email"
+          | "rejected_by_email";
+      }> = [
+        {
+          idKey: "previous_owner_id",
+          nameKey: "previous_owner_name",
+          emailKey: "previous_owner_email",
+        },
+        {
+          idKey: "new_owner_id",
+          nameKey: "new_owner_name",
+          emailKey: "new_owner_email",
+        },
+        {
+          idKey: "target_user_id",
+          nameKey: "target_name",
+          emailKey: "target_email",
+        },
+        {
+          idKey: "rejected_by_user_id",
+          nameKey: "rejected_by_name",
+          emailKey: "rejected_by_email",
+        },
+      ];
+
+      for (const mapping of transferUserMappings) {
+        const mappedId = parseMaybeUuid(metadata[mapping.idKey]);
+        if (!mappedId) continue;
+
+        const existingName =
+          typeof metadata[mapping.nameKey] === "string"
+            ? (metadata[mapping.nameKey] as string)
+            : "";
+        const existingEmail =
+          typeof metadata[mapping.emailKey] === "string"
+            ? (metadata[mapping.emailKey] as string)
+            : "";
+
+        metadata[mapping.nameKey] =
+          userNameById.get(mappedId) ||
+          existingName ||
+          existingEmail ||
+          "Former Member";
+        metadata[mapping.emailKey] =
+          userEmailById.get(mappedId) || existingEmail || "";
       }
 
       return {

--- a/src/app/api/projects/[id]/transfer/accept/route.ts
+++ b/src/app/api/projects/[id]/transfer/accept/route.ts
@@ -1,0 +1,302 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logAuditEvent } from "@/lib/audit-logger";
+import {
+  cacheDel,
+  CacheKeys,
+  invalidateProjectCaches,
+  invalidateUserSecretAccess,
+} from "@/lib/cache";
+import { headers } from "next/headers";
+import { transferRateLimit } from "@/lib/ratelimit";
+
+const ParamsSchema = z.object({ id: z.string().uuid("Invalid project ID") });
+const AcceptTransferSchema = z.object({
+  transferRequestId: z.string().uuid("Invalid transfer request ID").optional(),
+});
+
+type ProjectTransferRequest = {
+  id: string;
+  project_id: string;
+  current_owner_id: string;
+  target_user_id: string;
+  current_owner_action: "demote_to_editor" | "remove_from_project";
+  expires_at: string;
+};
+
+type ExecuteTransferResult = {
+  previous_owner_id: string;
+  new_owner_id: string;
+  owner_action: "demote_to_editor" | "remove_from_project";
+  transferred_secret_count: number;
+};
+
+type ProfileRow = {
+  username: string | null;
+};
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const parsedParams = ParamsSchema.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Invalid project ID" }, { status: 400 });
+  }
+
+  let payload: z.infer<typeof AcceptTransferSchema> = {};
+  try {
+    const raw = await request.json().catch(() => ({}));
+    payload = AcceptTransferSchema.parse(raw);
+  } catch (error) {
+    const message =
+      error instanceof z.ZodError
+        ? error.issues[0]?.message || "Invalid request body"
+        : "Invalid request body";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const projectId = parsedParams.data.id;
+  const admin = createAdminClient();
+  const now = new Date().toISOString();
+  const ip = (await headers()).get("x-forwarded-for") || "unknown";
+  const { success: rateLimitSuccess } = await transferRateLimit.limit(
+    `transfer_accept_${user.id || ip}`,
+  );
+  if (!rateLimitSuccess) {
+    return NextResponse.json(
+      { error: "Too many transfer actions. Please try again later." },
+      { status: 429 },
+    );
+  }
+
+  await admin
+    .from("project_transfer_requests")
+    .update({ status: "expired", responded_at: now })
+    .eq("project_id", projectId)
+    .eq("status", "pending")
+    .lte("expires_at", now);
+
+  let requestQuery = admin
+    .from("project_transfer_requests")
+    .select(
+      "id, project_id, current_owner_id, target_user_id, current_owner_action, expires_at",
+    )
+    .eq("project_id", projectId)
+    .eq("target_user_id", user.id)
+    .eq("status", "pending")
+    .order("created_at", { ascending: false })
+    .limit(1);
+
+  if (payload.transferRequestId) {
+    requestQuery = requestQuery.eq("id", payload.transferRequestId);
+  }
+
+  const { data: pendingRequests, error: requestError } = await requestQuery;
+
+  if (requestError) {
+    return NextResponse.json({ error: requestError.message }, { status: 500 });
+  }
+
+  const transferRequest =
+    (pendingRequests?.[0] as ProjectTransferRequest | undefined) || null;
+
+  if (!transferRequest) {
+    return NextResponse.json(
+      { error: "No pending transfer request found for this project." },
+      { status: 404 },
+    );
+  }
+
+  if (transferRequest.expires_at <= now) {
+    await admin
+      .from("project_transfer_requests")
+      .update({ status: "expired", responded_at: now })
+      .eq("id", transferRequest.id);
+
+    return NextResponse.json(
+      { error: "Transfer request has expired." },
+      { status: 410 },
+    );
+  }
+
+  const { data: project } = await admin
+    .from("projects")
+    .select("id, name, slug")
+    .eq("id", projectId)
+    .maybeSingle();
+
+  const { data: transferResult, error: rpcError } = await admin.rpc(
+    "execute_project_transfer",
+    {
+      p_transfer_request_id: transferRequest.id,
+      p_project_id: projectId,
+      p_actor_user_id: user.id,
+    },
+  );
+
+  if (rpcError) {
+    const message = rpcError.message || "Failed to accept transfer request.";
+    const lowered = message.toLowerCase();
+
+    if (lowered.includes("expired")) {
+      return NextResponse.json(
+        { error: "Transfer request has expired." },
+        { status: 410 },
+      );
+    }
+    if (lowered.includes("target_mismatch")) {
+      return NextResponse.json(
+        { error: "Only the intended recipient can accept this transfer." },
+        { status: 403 },
+      );
+    }
+
+    return NextResponse.json({ error: message }, { status: 409 });
+  }
+
+  const resultRow = Array.isArray(transferResult)
+    ? (transferResult[0] as ExecuteTransferResult | undefined)
+    : (transferResult as ExecuteTransferResult | null);
+
+  if (!resultRow) {
+    return NextResponse.json(
+      { error: "Transfer completed but no result metadata was returned." },
+      { status: 500 },
+    );
+  }
+
+  let previousOwnerName = `user-${resultRow.previous_owner_id.slice(0, 8)}`;
+  let previousOwnerEmail = "";
+  let newOwnerName =
+    user.user_metadata?.username ||
+    user.user_metadata?.name ||
+    user.email ||
+    `user-${resultRow.new_owner_id.slice(0, 8)}`;
+  let newOwnerEmail = user.email || "";
+
+  try {
+    const [
+      { data: previousOwnerAuth },
+      { data: previousOwnerProfile },
+      { data: newOwnerAuth },
+      { data: newOwnerProfile },
+    ] = await Promise.all([
+      admin.auth.admin.getUserById(resultRow.previous_owner_id),
+      admin
+        .from("profiles")
+        .select("username")
+        .eq("id", resultRow.previous_owner_id)
+        .maybeSingle<ProfileRow>(),
+      admin.auth.admin.getUserById(resultRow.new_owner_id),
+      admin
+        .from("profiles")
+        .select("username")
+        .eq("id", resultRow.new_owner_id)
+        .maybeSingle<ProfileRow>(),
+    ]);
+
+    previousOwnerEmail = previousOwnerAuth?.user?.email || previousOwnerEmail;
+    previousOwnerName =
+      previousOwnerProfile?.username ||
+      previousOwnerAuth?.user?.user_metadata?.username ||
+      previousOwnerAuth?.user?.user_metadata?.name ||
+      previousOwnerEmail ||
+      previousOwnerName;
+
+    newOwnerEmail = newOwnerAuth?.user?.email || newOwnerEmail;
+    newOwnerName =
+      newOwnerProfile?.username ||
+      newOwnerAuth?.user?.user_metadata?.username ||
+      newOwnerAuth?.user?.user_metadata?.name ||
+      newOwnerEmail ||
+      String(newOwnerName);
+  } catch (identityError) {
+    console.warn("[transfer:accept] identity enrichment failed", identityError);
+  }
+
+  await logAuditEvent({
+    projectId,
+    actorId: user.id,
+    actorType: "user",
+    action: "transfer.accepted",
+    targetResourceId: transferRequest.id,
+    metadata: {
+      event_code: "TRANSFER_ACCEPTED",
+      transfer_request_id: transferRequest.id,
+      previous_owner_id: resultRow.previous_owner_id,
+      previous_owner_name: previousOwnerName,
+      previous_owner_email: previousOwnerEmail,
+      new_owner_id: resultRow.new_owner_id,
+      new_owner_name: newOwnerName,
+      new_owner_email: newOwnerEmail,
+      current_owner_action: resultRow.owner_action,
+      previous_owner_disposition: resultRow.owner_action,
+      granted_role: "owner",
+      granted_access: "project.owner",
+      transferred_secret_count: resultRow.transferred_secret_count,
+      beneficiary_user_id: resultRow.new_owner_id,
+      beneficiary_name: newOwnerName,
+      beneficiary_email: newOwnerEmail,
+    },
+  });
+
+  try {
+    const [{ createOwnershipTransferAcceptedNotification }, { sendOwnershipTransferAcceptedEmail }] =
+      await Promise.all([import("@/lib/notifications"), import("@/lib/email")]);
+    const projectName = project?.name || "Project";
+
+    await createOwnershipTransferAcceptedNotification(
+      resultRow.previous_owner_id,
+      projectName,
+      projectId,
+      String(newOwnerName),
+    );
+
+    if (previousOwnerEmail) {
+      await sendOwnershipTransferAcceptedEmail(
+        previousOwnerEmail,
+        projectName,
+        String(newOwnerName),
+        resultRow.previous_owner_id,
+      );
+    }
+  } catch (notifyError) {
+    console.error(
+      "[transfer:accept] notification dispatch failed",
+      notifyError,
+    );
+  }
+
+  await Promise.all([
+    cacheDel(CacheKeys.userProjects(resultRow.previous_owner_id)),
+    cacheDel(CacheKeys.userProjects(resultRow.new_owner_id)),
+    cacheDel(CacheKeys.userProjectRole(resultRow.previous_owner_id, projectId)),
+    cacheDel(CacheKeys.userProjectRole(resultRow.new_owner_id, projectId)),
+    cacheDel(CacheKeys.projectMembers(projectId)),
+    invalidateUserSecretAccess(resultRow.previous_owner_id),
+    invalidateUserSecretAccess(resultRow.new_owner_id),
+    invalidateProjectCaches(projectId),
+  ]);
+
+  return NextResponse.json({
+    success: true,
+    transfer: {
+      previousOwnerId: resultRow.previous_owner_id,
+      newOwnerId: resultRow.new_owner_id,
+      previousOwnerDisposition: resultRow.owner_action,
+      transferredSecrets: resultRow.transferred_secret_count,
+    },
+  });
+}

--- a/src/app/api/projects/[id]/transfer/initiate/route.ts
+++ b/src/app/api/projects/[id]/transfer/initiate/route.ts
@@ -1,0 +1,286 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getProjectRole } from "@/lib/permissions";
+import { logAuditEvent } from "@/lib/audit-logger";
+import { headers } from "next/headers";
+import { transferRateLimit } from "@/lib/ratelimit";
+
+const ParamsSchema = z.object({ id: z.string().uuid("Invalid project ID") });
+
+const InitiateTransferSchema = z
+  .object({
+    targetUserId: z.string().uuid("Invalid target user ID").optional(),
+    targetEmail: z.string().email("Invalid target email").optional(),
+    currentOwnerAction: z
+      .enum(["demote_to_editor", "remove_from_project"])
+      .optional(),
+  })
+  .refine((value) => value.targetUserId || value.targetEmail, {
+    message: "Provide targetUserId or targetEmail",
+    path: ["targetUserId"],
+  });
+
+async function resolveTargetUserId(
+  admin: ReturnType<typeof createAdminClient>,
+  payload: z.infer<typeof InitiateTransferSchema>,
+): Promise<string | null> {
+  if (payload.targetUserId) {
+    return payload.targetUserId;
+  }
+
+  const targetEmail = payload.targetEmail?.trim().toLowerCase();
+  if (!targetEmail) {
+    return null;
+  }
+
+  const { data, error } = await admin.rpc("get_user_id_by_email", {
+    email_input: targetEmail,
+  });
+
+  if (error) {
+    console.error("[transfer:initiate] Failed to resolve user by email", error);
+    return null;
+  }
+
+  return typeof data === "string" ? data : null;
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const parsedParams = ParamsSchema.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Invalid project ID" }, { status: 400 });
+  }
+
+  let payload: z.infer<typeof InitiateTransferSchema>;
+  try {
+    payload = InitiateTransferSchema.parse(await request.json());
+  } catch (error) {
+    const message =
+      error instanceof z.ZodError
+        ? error.issues[0]?.message || "Invalid request body"
+        : "Invalid request body";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const projectId = parsedParams.data.id;
+  const ip = (await headers()).get("x-forwarded-for") || "unknown";
+  const { success: rateLimitSuccess } = await transferRateLimit.limit(
+    `transfer_initiate_${user.id || ip}`,
+  );
+  if (!rateLimitSuccess) {
+    return NextResponse.json(
+      { error: "Too many transfer requests. Please try again later." },
+      { status: 429 },
+    );
+  }
+
+  const role = await getProjectRole(supabase, projectId, user.id);
+  if (role !== "owner") {
+    return NextResponse.json(
+      { error: "Only the project owner can initiate ownership transfer." },
+      { status: 403 },
+    );
+  }
+
+  const admin = createAdminClient();
+
+  const { data: project } = await admin
+    .from("projects")
+    .select("id, name, slug, user_id")
+    .eq("id", projectId)
+    .single();
+
+  if (!project) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  if (project.user_id !== user.id) {
+    return NextResponse.json(
+      { error: "Only the current owner can initiate transfer." },
+      { status: 403 },
+    );
+  }
+
+  const targetUserId = await resolveTargetUserId(admin, payload);
+  if (!targetUserId) {
+    return NextResponse.json(
+      { error: "Target user not found. They must have an Envault account." },
+      { status: 404 },
+    );
+  }
+
+  if (targetUserId === user.id) {
+    return NextResponse.json(
+      { error: "Ownership cannot be transferred to the current owner." },
+      { status: 400 },
+    );
+  }
+
+  const now = new Date().toISOString();
+
+  // Ensure stale requests are expired first so they do not block new transfers.
+  await admin
+    .from("project_transfer_requests")
+    .update({ status: "expired", responded_at: now })
+    .eq("project_id", projectId)
+    .eq("status", "pending")
+    .lte("expires_at", now);
+
+  const { data: pendingRequest } = await admin
+    .from("project_transfer_requests")
+    .select("id, expires_at, target_user_id")
+    .eq("project_id", projectId)
+    .eq("status", "pending")
+    .gt("expires_at", now)
+    .maybeSingle();
+
+  if (pendingRequest) {
+    return NextResponse.json(
+      {
+        error:
+          "A pending ownership transfer already exists for this project. Resolve it before creating a new one.",
+        requestId: pendingRequest.id,
+        expiresAt: pendingRequest.expires_at,
+      },
+      { status: 409 },
+    );
+  }
+
+  const ownerAction = payload.currentOwnerAction || "demote_to_editor";
+
+  const { data: createdRequest, error: insertError } = await admin
+    .from("project_transfer_requests")
+    .insert({
+      project_id: projectId,
+      current_owner_id: user.id,
+      target_user_id: targetUserId,
+      initiated_by: user.id,
+      current_owner_action: ownerAction,
+      status: "pending",
+      expires_at: new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString(),
+    })
+    .select("id, target_user_id, expires_at, current_owner_action")
+    .single();
+
+  if (insertError) {
+    if (insertError.code === "23505") {
+      return NextResponse.json(
+        {
+          error:
+            "A pending ownership transfer already exists for this project. Resolve it before creating a new one.",
+        },
+        { status: 409 },
+      );
+    }
+
+    return NextResponse.json({ error: insertError.message }, { status: 500 });
+  }
+
+  let targetEmail = "";
+  let targetName = `user-${targetUserId.slice(0, 8)}`;
+  let ownerName =
+    user.user_metadata?.username ||
+    user.user_metadata?.name ||
+    user.email ||
+    `user-${user.id.slice(0, 8)}`;
+  try {
+    const [{ data: targetUserAuth }, { data: ownerProfile }, { data: targetProfile }] =
+      await Promise.all([
+      admin.auth.admin.getUserById(targetUserId),
+      admin.from("profiles").select("username").eq("id", user.id).maybeSingle(),
+      admin
+        .from("profiles")
+        .select("username")
+        .eq("id", targetUserId)
+        .maybeSingle(),
+    ]);
+
+    targetEmail = targetUserAuth?.user?.email || "";
+    targetName =
+      targetProfile?.username ||
+      targetUserAuth?.user?.user_metadata?.username ||
+      targetUserAuth?.user?.user_metadata?.name ||
+      targetEmail ||
+      targetName;
+    ownerName = ownerProfile?.username || ownerName;
+  } catch (identityError) {
+    console.warn("[transfer:initiate] identity enrichment failed", identityError);
+  }
+
+  await logAuditEvent({
+    projectId,
+    actorId: user.id,
+    actorType: "user",
+    action: "transfer.requested",
+    targetResourceId: createdRequest.id,
+    metadata: {
+      event_code: "TRANSFER_REQUESTED",
+      transfer_request_id: createdRequest.id,
+      project_name: project.name,
+      target_user_id: createdRequest.target_user_id,
+      target_name: targetName,
+      target_email: targetEmail,
+      previous_owner_id: user.id,
+      previous_owner_name: ownerName,
+      previous_owner_email: user.email || "",
+      current_owner_action: createdRequest.current_owner_action,
+      expires_at: createdRequest.expires_at,
+      beneficiary_user_id: createdRequest.target_user_id,
+      beneficiary_name: targetName,
+      beneficiary_email: targetEmail,
+      granted_role: "owner (pending acceptance)",
+    },
+  });
+
+  try {
+    const [{ createOwnershipTransferRequestedNotification }, { sendOwnershipTransferRequestedEmail }] =
+      await Promise.all([import("@/lib/notifications"), import("@/lib/email")]);
+
+    await createOwnershipTransferRequestedNotification(
+      targetUserId,
+      project.name,
+      projectId,
+      String(ownerName),
+      createdRequest.id,
+    );
+
+    if (targetEmail && targetEmail.trim()) {
+      await sendOwnershipTransferRequestedEmail(
+        targetEmail,
+        project.name,
+        String(ownerName),
+        createdRequest.id,
+        targetUserId,
+      );
+    }
+  } catch (notifyError) {
+    console.error(
+      "[transfer:initiate] notification dispatch failed",
+      notifyError,
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    request: {
+      id: createdRequest.id,
+      targetUserId: createdRequest.target_user_id,
+      expiresAt: createdRequest.expires_at,
+      currentOwnerAction: createdRequest.current_owner_action,
+    },
+  });
+}

--- a/src/app/api/projects/[id]/transfer/reject/route.ts
+++ b/src/app/api/projects/[id]/transfer/reject/route.ts
@@ -1,0 +1,232 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logAuditEvent } from "@/lib/audit-logger";
+import { headers } from "next/headers";
+import { transferRateLimit } from "@/lib/ratelimit";
+
+const ParamsSchema = z.object({ id: z.string().uuid("Invalid project ID") });
+const RejectTransferSchema = z.object({
+  transferRequestId: z.string().uuid("Invalid transfer request ID").optional(),
+});
+
+type ProjectTransferRequest = {
+  id: string;
+  current_owner_id: string;
+  target_user_id: string;
+  expires_at: string;
+};
+
+type ProfileRow = {
+  username: string | null;
+};
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const parsedParams = ParamsSchema.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Invalid project ID" }, { status: 400 });
+  }
+
+  let payload: z.infer<typeof RejectTransferSchema> = {};
+  try {
+    const raw = await request.json().catch(() => ({}));
+    payload = RejectTransferSchema.parse(raw);
+  } catch (error) {
+    const message =
+      error instanceof z.ZodError
+        ? error.issues[0]?.message || "Invalid request body"
+        : "Invalid request body";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const projectId = parsedParams.data.id;
+  const admin = createAdminClient();
+  const now = new Date().toISOString();
+  const ip = (await headers()).get("x-forwarded-for") || "unknown";
+  const { success: rateLimitSuccess } = await transferRateLimit.limit(
+    `transfer_reject_${user.id || ip}`,
+  );
+  if (!rateLimitSuccess) {
+    return NextResponse.json(
+      { error: "Too many transfer actions. Please try again later." },
+      { status: 429 },
+    );
+  }
+
+  await admin
+    .from("project_transfer_requests")
+    .update({ status: "expired", responded_at: now })
+    .eq("project_id", projectId)
+    .eq("status", "pending")
+    .lte("expires_at", now);
+
+  let requestQuery = admin
+    .from("project_transfer_requests")
+    .select("id, current_owner_id, target_user_id, expires_at")
+    .eq("project_id", projectId)
+    .eq("target_user_id", user.id)
+    .eq("status", "pending")
+    .order("created_at", { ascending: false })
+    .limit(1);
+
+  if (payload.transferRequestId) {
+    requestQuery = requestQuery.eq("id", payload.transferRequestId);
+  }
+
+  const { data: pendingRequests, error: requestError } = await requestQuery;
+
+  if (requestError) {
+    return NextResponse.json({ error: requestError.message }, { status: 500 });
+  }
+
+  const transferRequest =
+    (pendingRequests?.[0] as ProjectTransferRequest | undefined) || null;
+
+  if (!transferRequest) {
+    return NextResponse.json(
+      { error: "No pending transfer request found for this project." },
+      { status: 404 },
+    );
+  }
+
+  if (transferRequest.expires_at <= now) {
+    await admin
+      .from("project_transfer_requests")
+      .update({ status: "expired", responded_at: now })
+      .eq("id", transferRequest.id);
+
+    return NextResponse.json(
+      { error: "Transfer request has expired." },
+      { status: 410 },
+    );
+  }
+
+  const { data: project } = await admin
+    .from("projects")
+    .select("id, name, slug")
+    .eq("id", projectId)
+    .maybeSingle();
+
+  const { error: rejectError } = await admin
+    .from("project_transfer_requests")
+    .update({ status: "rejected", responded_at: now })
+    .eq("id", transferRequest.id)
+    .eq("status", "pending");
+
+  if (rejectError) {
+    return NextResponse.json({ error: rejectError.message }, { status: 500 });
+  }
+
+  let previousOwnerName = `user-${transferRequest.current_owner_id.slice(0, 8)}`;
+  let previousOwnerEmail = "";
+  let rejectedByName =
+    user.user_metadata?.username ||
+    user.user_metadata?.name ||
+    user.email ||
+    `user-${user.id.slice(0, 8)}`;
+  let rejectedByEmail = user.email || "";
+
+  try {
+    const [
+      { data: previousOwnerAuth },
+      { data: previousOwnerProfile },
+      { data: rejectedByAuth },
+      { data: rejectedByProfile },
+    ] = await Promise.all([
+      admin.auth.admin.getUserById(transferRequest.current_owner_id),
+      admin
+        .from("profiles")
+        .select("username")
+        .eq("id", transferRequest.current_owner_id)
+        .maybeSingle<ProfileRow>(),
+      admin.auth.admin.getUserById(transferRequest.target_user_id),
+      admin
+        .from("profiles")
+        .select("username")
+        .eq("id", transferRequest.target_user_id)
+        .maybeSingle<ProfileRow>(),
+    ]);
+
+    previousOwnerEmail = previousOwnerAuth?.user?.email || previousOwnerEmail;
+    previousOwnerName =
+      previousOwnerProfile?.username ||
+      previousOwnerAuth?.user?.user_metadata?.username ||
+      previousOwnerAuth?.user?.user_metadata?.name ||
+      previousOwnerEmail ||
+      previousOwnerName;
+
+    rejectedByEmail = rejectedByAuth?.user?.email || rejectedByEmail;
+    rejectedByName =
+      rejectedByProfile?.username ||
+      rejectedByAuth?.user?.user_metadata?.username ||
+      rejectedByAuth?.user?.user_metadata?.name ||
+      rejectedByEmail ||
+      String(rejectedByName);
+  } catch (identityError) {
+    console.warn("[transfer:reject] identity enrichment failed", identityError);
+  }
+
+  await logAuditEvent({
+    projectId,
+    actorId: user.id,
+    actorType: "user",
+    action: "transfer.rejected",
+    targetResourceId: transferRequest.id,
+    metadata: {
+      event_code: "TRANSFER_REJECTED",
+      transfer_request_id: transferRequest.id,
+      previous_owner_id: transferRequest.current_owner_id,
+      previous_owner_name: previousOwnerName,
+      previous_owner_email: previousOwnerEmail,
+      rejected_by_user_id: transferRequest.target_user_id,
+      rejected_by_name: rejectedByName,
+      rejected_by_email: rejectedByEmail,
+      requested_role: "owner",
+      beneficiary_user_id: transferRequest.current_owner_id,
+      beneficiary_name: previousOwnerName,
+      beneficiary_email: previousOwnerEmail,
+    },
+  });
+
+  try {
+    const [{ createOwnershipTransferRejectedNotification }, { sendOwnershipTransferRejectedEmail }] =
+      await Promise.all([import("@/lib/notifications"), import("@/lib/email")]);
+    const projectName = project?.name || "Project";
+
+    await createOwnershipTransferRejectedNotification(
+      transferRequest.current_owner_id,
+      projectName,
+      projectId,
+      String(rejectedByName),
+    );
+
+    if (previousOwnerEmail) {
+      await sendOwnershipTransferRejectedEmail(
+        previousOwnerEmail,
+        projectName,
+        String(rejectedByName),
+        transferRequest.current_owner_id,
+      );
+    }
+  } catch (notifyError) {
+    console.error(
+      "[transfer:reject] notification dispatch failed",
+      notifyError,
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/project/[slug]/page.tsx
+++ b/src/app/project/[slug]/page.tsx
@@ -359,8 +359,12 @@ export default async function ProjectPage({ params, searchParams }: PageProps) {
           }
         }
 
-        const creatorFromMap = secret.user_id
-          ? userMap.get(secret.user_id)
+        const creatorSnapshotId =
+          (secret.created_by_user_id_snapshot as string | undefined) ||
+          secret.user_id ||
+          undefined;
+        const creatorFromMap = creatorSnapshotId
+          ? userMap.get(creatorSnapshotId)
           : undefined;
         const creator = secret.user_id
           ? secret.created_by_name || secret.created_by_email
@@ -376,13 +380,13 @@ export default async function ProjectPage({ params, searchParams }: PageProps) {
             : creatorFromMap
           : undefined;
 
-        const updaterFromMap = secret.last_updated_by
-          ? userMap.get(secret.last_updated_by)
-          : undefined;
         const updaterSnapshotId =
           (secret.last_updated_by_user_id_snapshot as string | undefined) ||
           secret.last_updated_by ||
           undefined;
+        const updaterFromMap = updaterSnapshotId
+          ? userMap.get(updaterSnapshotId)
+          : undefined;
         const updater =
           updaterSnapshotId ||
           secret.last_updated_by_name ||

--- a/src/app/transfer/[requestId]/page.tsx
+++ b/src/app/transfer/[requestId]/page.tsx
@@ -1,0 +1,184 @@
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { AuthLayout } from "@/components/auth/auth-layout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { CardDescription, CardFooter } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { ArrowRightLeft, Lock, XCircle } from "lucide-react";
+import { TransferRequestActions } from "./transfer-request-actions";
+
+interface TransferRequestPageProps {
+  params: Promise<{ requestId: string }>;
+}
+
+type TransferRequestRow = {
+  id: string;
+  project_id: string;
+  target_user_id: string;
+  status: "pending" | "accepted" | "rejected" | "expired";
+  expires_at: string;
+  projects?: {
+    name?: string;
+  } | null;
+};
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}
+
+export default async function TransferRequestPage({
+  params,
+}: TransferRequestPageProps) {
+  const { requestId } = await params;
+
+  if (!isUuid(requestId)) {
+    notFound();
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/login?next=/transfer/${requestId}`);
+  }
+
+  const admin = createAdminClient();
+  const { data: request } = await admin
+    .from("project_transfer_requests")
+    .select("id, project_id, target_user_id, status, expires_at, projects(name)")
+    .eq("id", requestId)
+    .maybeSingle();
+
+  const transferRequest = request as TransferRequestRow | null;
+
+  if (!transferRequest) {
+    return (
+      <AuthLayout>
+        <div className="w-[90vw] sm:w-full sm:max-w-md mx-auto">
+          <Card className="border-muted/40 shadow-2xl backdrop-blur-sm bg-background/80">
+            <CardHeader className="text-center space-y-2">
+              <div className="flex justify-center mb-2">
+                <div className="p-3 bg-destructive/10 rounded-full">
+                  <XCircle className="w-10 h-10 text-destructive" />
+                </div>
+              </div>
+              <CardTitle className="text-2xl font-bold tracking-tight">
+                Request Unavailable
+              </CardTitle>
+              <CardDescription>
+                This ownership transfer request may have been completed,
+                rejected, expired, or removed.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button asChild className="w-full h-11" variant="outline">
+                <Link href="/dashboard">Return to Dashboard</Link>
+              </Button>
+            </CardContent>
+            <CardFooter className="justify-center text-xs text-muted-foreground">
+              <Lock className="w-3 h-3 mr-1" />
+              End-to-end encrypted environment
+            </CardFooter>
+          </Card>
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  if (transferRequest.target_user_id !== user.id) {
+    return (
+      <AuthLayout>
+        <div className="w-[90vw] sm:w-full sm:max-w-md mx-auto">
+          <Card className="border-muted/40 shadow-2xl backdrop-blur-sm bg-background/80">
+            <CardHeader className="text-center space-y-2">
+              <div className="flex justify-center mb-2">
+                <div className="p-3 bg-destructive/10 rounded-full">
+                  <XCircle className="w-10 h-10 text-destructive" />
+                </div>
+              </div>
+              <CardTitle className="text-2xl font-bold tracking-tight">
+                Not Authorized
+              </CardTitle>
+              <CardDescription>
+                You are not the recipient of this ownership transfer request.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button asChild className="w-full h-11" variant="outline">
+                <Link href="/dashboard">Return to Dashboard</Link>
+              </Button>
+            </CardContent>
+            <CardFooter className="justify-center text-xs text-muted-foreground">
+              <Lock className="w-3 h-3 mr-1" />
+              End-to-end encrypted environment
+            </CardFooter>
+          </Card>
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  const projectName = transferRequest.projects?.name || "Project";
+  const isActionable = transferRequest.status === "pending";
+
+  return (
+    <AuthLayout>
+      <div className="w-[90vw] sm:w-full sm:max-w-md mx-auto">
+        <Card className="border-muted/40 shadow-2xl backdrop-blur-sm bg-background/80">
+          <CardHeader className="text-center space-y-2">
+            <div className="flex justify-center mb-2">
+              <div className="p-3 bg-primary/10 rounded-full">
+                <ArrowRightLeft className="w-10 h-10 text-primary" />
+              </div>
+            </div>
+            <CardTitle className="text-2xl font-bold tracking-tight">
+              Ownership Transfer Request
+            </CardTitle>
+            <CardDescription>
+              You were requested to become the owner of{" "}
+              <span className="font-medium text-foreground">{projectName}</span>.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <p className="text-sm text-muted-foreground text-center">
+              Expires at: {new Date(transferRequest.expires_at).toLocaleString()}
+            </p>
+
+            {isActionable ? (
+              <div className="w-full">
+                <TransferRequestActions
+                  requestId={transferRequest.id}
+                  projectId={transferRequest.project_id}
+                  projectName={projectName}
+                />
+              </div>
+            ) : (
+              <Alert>
+                <AlertTitle>Request Not Actionable</AlertTitle>
+                <AlertDescription>
+                  This request is currently marked as{" "}
+                  <strong>{transferRequest.status}</strong>.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <Button variant="ghost" asChild className="w-full h-11">
+              <Link href="/dashboard">Back to Dashboard</Link>
+            </Button>
+          </CardContent>
+          <CardFooter className="justify-center text-xs text-muted-foreground">
+            <Lock className="w-3 h-3 mr-1" />
+            End-to-end encrypted environment
+          </CardFooter>
+        </Card>
+      </div>
+    </AuthLayout>
+  );
+}

--- a/src/app/transfer/[requestId]/transfer-request-actions.tsx
+++ b/src/app/transfer/[requestId]/transfer-request-actions.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface TransferRequestActionsProps {
+  requestId: string;
+  projectId: string;
+  projectName: string;
+}
+
+export function TransferRequestActions({
+  requestId,
+  projectId,
+  projectName,
+}: TransferRequestActionsProps) {
+  const router = useRouter();
+  const [isPending, setIsPending] = useState<"accept" | "reject" | null>(
+    null,
+  );
+
+  const submitAction = async (action: "accept" | "reject") => {
+    setIsPending(action);
+
+    try {
+      const response = await fetch(`/api/projects/${projectId}/transfer/${action}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transferRequestId: requestId }),
+      });
+
+      const body = (await response.json().catch(() => ({}))) as {
+        error?: string;
+      };
+
+      if (!response.ok) {
+        toast.error(body.error || `Failed to ${action} transfer request.`);
+        return;
+      }
+
+      toast.success(
+        action === "accept"
+          ? `You are now the owner of ${projectName}.`
+          : `Transfer request for ${projectName} was rejected.`,
+      );
+
+      router.push("/dashboard");
+      router.refresh();
+    } catch (error) {
+      console.error(`[transfer:${action}] request failed`, error);
+      toast.error(`Failed to ${action} transfer request.`);
+    } finally {
+      setIsPending(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col sm:flex-row gap-2 w-full">
+      <Button
+        variant="outline"
+        className="w-full sm:flex-1 h-11"
+        disabled={isPending !== null}
+        onClick={() => submitAction("reject")}
+      >
+        {isPending === "reject" ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Rejecting...
+          </>
+        ) : (
+          "Reject"
+        )}
+      </Button>
+      <Button
+        className="w-full sm:flex-1 h-11"
+        disabled={isPending !== null}
+        onClick={() => submitAction("accept")}
+      >
+        {isPending === "accept" ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Accepting...
+          </>
+        ) : (
+          "Accept Transfer"
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/dashboard/audit-logs-view.tsx
+++ b/src/components/dashboard/audit-logs-view.tsx
@@ -22,6 +22,7 @@ import {
   ShieldCheck,
   ShieldOff,
   Trash2,
+  ArrowRightLeft,
   UserCog,
   UserMinus,
   UserPlus,
@@ -52,6 +53,24 @@ interface AuditLogMetadata {
   count?: number;
   role?: string;
   member_user_id?: string;
+  target_user_id?: string;
+  target_name?: string;
+  target_email?: string;
+  previous_owner_id?: string;
+  previous_owner_name?: string;
+  previous_owner_email?: string;
+  new_owner_id?: string;
+  new_owner_name?: string;
+  new_owner_email?: string;
+  rejected_by_user_id?: string;
+  rejected_by_name?: string;
+  rejected_by_email?: string;
+  current_owner_action?: "demote_to_editor" | "remove_from_project";
+  previous_owner_disposition?: "demote_to_editor" | "remove_from_project";
+  granted_role?: string;
+  granted_access?: string;
+  requested_role?: string;
+  transferred_secret_count?: number;
   beneficiary_user_id?: string;
   beneficiary_name?: string;
   beneficiary_email?: string;
@@ -67,6 +86,11 @@ interface AuditLog {
   actor_name?: string;
   actor_avatar?: string;
   metadata?: AuditLogMetadata;
+}
+
+interface DetailRow {
+  label: string;
+  value: string;
 }
 
 interface ProjectMemberOption {
@@ -89,6 +113,9 @@ const ACTION_OPTIONS = [
   { value: "member.invited", label: "Member Invited" },
   { value: "member.role_updated", label: "Member Role Updated" },
   { value: "member.removed", label: "Member Removed" },
+  { value: "transfer.requested", label: "Ownership Transfer Requested" },
+  { value: "transfer.accepted", label: "Ownership Transfer Accepted" },
+  { value: "transfer.rejected", label: "Ownership Transfer Rejected" },
   { value: "environment.access_updated", label: "Environment Access Updated" },
   { value: "environment.access_granted", label: "Environment Access Granted" },
   { value: "environment.access_revoked", label: "Environment Access Revoked" },
@@ -134,6 +161,124 @@ function getBeneficiaryLabel(metadata?: AuditLogMetadata): string | null {
   );
 }
 
+function firstNonEmpty(...values: Array<string | null | undefined>): string {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return "";
+}
+
+function getTransferDispositionLabel(
+  value: AuditLogMetadata["previous_owner_disposition"],
+): string {
+  if (value === "demote_to_editor") return "Demoted to Editor";
+  if (value === "remove_from_project") return "Removed from Project";
+  return "";
+}
+
+function getGrantedAccessLabel(metadata: AuditLogMetadata): string {
+  const raw = firstNonEmpty(metadata.granted_access, metadata.granted_role);
+  if (!raw) return "";
+  if (raw.toLowerCase().includes("owner")) return "Owner";
+  return raw
+    .replace(/[_\.]/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function getRequestedAccessLabel(metadata: AuditLogMetadata): string {
+  const raw = firstNonEmpty(metadata.requested_role);
+  if (!raw) return "";
+  if (raw.toLowerCase().includes("owner")) return "Owner";
+  return raw
+    .replace(/[_\.]/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function getTransferDetailRows(
+  action: string,
+  metadata: AuditLogMetadata | undefined,
+): DetailRow[] {
+  if (!metadata || !action.startsWith("transfer.")) {
+    return [];
+  }
+
+  const rows: DetailRow[] = [];
+  const previousOwner = firstNonEmpty(
+    metadata.previous_owner_name,
+    metadata.previous_owner_email,
+    metadata.previous_owner_id,
+  );
+  const targetUser = firstNonEmpty(
+    metadata.target_name,
+    metadata.target_email,
+    metadata.target_user_id,
+  );
+  const newOwner = firstNonEmpty(
+    metadata.new_owner_name,
+    metadata.new_owner_email,
+    metadata.new_owner_id,
+    metadata.beneficiary_name,
+    metadata.beneficiary_email,
+    metadata.beneficiary_user_id,
+  );
+  const rejectedBy = firstNonEmpty(
+    metadata.rejected_by_name,
+    metadata.rejected_by_email,
+    metadata.rejected_by_user_id,
+  );
+  const granted = getGrantedAccessLabel(metadata);
+  const requested = getRequestedAccessLabel(metadata);
+  const disposition = getTransferDispositionLabel(
+    metadata.previous_owner_disposition || metadata.current_owner_action,
+  );
+  const transferredCount =
+    typeof metadata.transferred_secret_count === "number"
+      ? metadata.transferred_secret_count
+      : null;
+
+  if (action === "transfer.requested") {
+    if (previousOwner) rows.push({ label: "Current Owner", value: previousOwner });
+    if (targetUser || newOwner) {
+      rows.push({ label: "Target User", value: targetUser || newOwner });
+    }
+    if (granted) rows.push({ label: "Requested Access", value: granted });
+    if (disposition) rows.push({ label: "On Acceptance", value: disposition });
+    return rows;
+  }
+
+  if (action === "transfer.accepted") {
+    if (previousOwner) rows.push({ label: "Previous Owner", value: previousOwner });
+    if (newOwner || targetUser) {
+      rows.push({ label: "New Owner", value: newOwner || targetUser });
+    }
+    if (granted) rows.push({ label: "Granted Access", value: granted });
+    if (disposition) rows.push({ label: "Previous Owner Access", value: disposition });
+    if (transferredCount !== null) {
+      rows.push({
+        label: "Secrets Reassigned",
+        value: String(transferredCount),
+      });
+    }
+    return rows;
+  }
+
+  if (action === "transfer.rejected") {
+    if (previousOwner) rows.push({ label: "Current Owner", value: previousOwner });
+    if (rejectedBy || targetUser || newOwner) {
+      rows.push({
+        label: "Rejected By",
+        value: rejectedBy || targetUser || newOwner,
+      });
+    }
+    if (requested) rows.push({ label: "Requested Access", value: requested });
+    return rows;
+  }
+
+  return rows;
+}
+
 function getActionIcon(action: string) {
   if (action === "secret.created") return <KeyRound className="h-3.5 w-3.5" />;
   if (action === "secret.updated")
@@ -144,6 +289,8 @@ function getActionIcon(action: string) {
   if (action === "member.role_updated")
     return <UserCog className="h-3.5 w-3.5" />;
   if (action === "member.removed") return <UserMinus className="h-3.5 w-3.5" />;
+  if (action.startsWith("transfer."))
+    return <ArrowRightLeft className="h-3.5 w-3.5" />;
   if (action === "environment.access_updated")
     return <RefreshCw className="h-3.5 w-3.5" />;
   if (action === "environment.access_granted")
@@ -240,6 +387,16 @@ function isMemberRelatedAction(action: string): boolean {
 }
 
 function getActionBadgeClass(action: string): string {
+  if (action === "transfer.requested") {
+    return "border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300";
+  }
+  if (action === "transfer.accepted") {
+    return "border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+  }
+  if (action === "transfer.rejected") {
+    return "border-rose-500/25 bg-rose-500/10 text-rose-700 dark:text-rose-300";
+  }
+
   if (
     action.includes("deleted") ||
     action.includes("removed") ||
@@ -354,6 +511,71 @@ function getNonDiffContextSummary(
 
   if (action === "member.removed") {
     return "Member removed from project";
+  }
+
+  if (action === "transfer.requested") {
+    const target = firstNonEmpty(
+      metadata?.target_name,
+      metadata?.target_email,
+      metadata?.beneficiary_name,
+      metadata?.beneficiary_email,
+      metadata?.target_user_id,
+      metadata?.beneficiary_user_id,
+    );
+    const grantedRole = metadata ? getGrantedAccessLabel(metadata) : "";
+    if (target && grantedRole) {
+      return `Ownership transfer requested to ${target}. Requested access: ${grantedRole}.`;
+    }
+    if (target) {
+      return `Ownership transfer requested to ${target}`;
+    }
+    return "Ownership transfer requested";
+  }
+
+  if (action === "transfer.accepted") {
+    const newOwner = firstNonEmpty(
+      metadata?.new_owner_name,
+      metadata?.new_owner_email,
+      metadata?.beneficiary_name,
+      metadata?.beneficiary_email,
+      metadata?.new_owner_id,
+      metadata?.beneficiary_user_id,
+    );
+    const granted = metadata ? getGrantedAccessLabel(metadata) : "";
+    const disposition = getTransferDispositionLabel(
+      metadata?.previous_owner_disposition || metadata?.current_owner_action,
+    );
+
+    if (newOwner && granted && disposition) {
+      return `Ownership transferred to ${newOwner}. Granted access: ${granted}. Previous owner access: ${disposition}.`;
+    }
+    if (newOwner && granted) {
+      return `Ownership transferred to ${newOwner}. Granted access: ${granted}.`;
+    }
+    if (newOwner) {
+      return `Ownership transfer accepted by ${newOwner}`;
+    }
+    return "Ownership transfer accepted";
+  }
+
+  if (action === "transfer.rejected") {
+    const rejectedBy = firstNonEmpty(
+      metadata?.rejected_by_name,
+      metadata?.rejected_by_email,
+      metadata?.target_name,
+      metadata?.target_email,
+      metadata?.rejected_by_user_id,
+      metadata?.target_user_id,
+    );
+    const requestedRole = metadata ? getRequestedAccessLabel(metadata) : "";
+
+    if (rejectedBy && requestedRole) {
+      return `Ownership transfer rejected by ${rejectedBy} (requested access: ${requestedRole})`;
+    }
+    if (rejectedBy) {
+      return `Ownership transfer rejected by ${rejectedBy}`;
+    }
+    return "Ownership transfer rejected";
   }
 
   if (action === "environment.access_granted") {
@@ -581,11 +803,16 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
             {logs.map((log) => {
               const changes = log.metadata?.changes || {};
               const keyName = log.metadata?.key_name;
+              const effectiveAction = getEffectiveAction(log);
               const changeEntries = Object.entries(changes);
-              const canExpand = changeEntries.length > 0;
+              const transferDetailRows = getTransferDetailRows(
+                effectiveAction,
+                log.metadata,
+              );
+              const canExpand =
+                changeEntries.length > 0 || transferDetailRows.length > 0;
               const isExpanded = expandedRows.has(log.id);
               const affectedUser = getBeneficiaryLabel(log.metadata);
-              const effectiveAction = getEffectiveAction(log);
               const actionText = getActionLabel(effectiveAction);
               const detailsSummary =
                 getNonDiffContextSummary(
@@ -593,7 +820,9 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                   log.metadata,
                   keyName,
                 ) ||
-                (!canExpand ? getDetailSummary(changeEntries, keyName) : null);
+                (changeEntries.length === 0
+                  ? getDetailSummary(changeEntries, keyName)
+                  : null);
               const shouldShowAffectedUser =
                 isMemberRelatedAction(effectiveAction) && Boolean(affectedUser);
 
@@ -605,7 +834,7 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                         <button
                           type="button"
                           aria-label={
-                            isExpanded ? "Collapse diff" : "Expand diff"
+                            isExpanded ? "Collapse details" : "Expand details"
                           }
                           onClick={() => toggleRow(log.id)}
                           className="inline-flex h-7 w-7 items-center justify-center rounded-md hover:bg-muted"
@@ -676,7 +905,7 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                           <span>{detailsSummary}</span>
                         ) : (
                           <span>
-                            {canExpand ? "Expand row to view changes" : "-"}
+                            {canExpand ? "Expand row to view details" : "-"}
                           </span>
                         )}
                       </div>
@@ -713,6 +942,19 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                               )}
                             </div>
                           ))}
+                          {transferDetailRows.map((row) => (
+                            <div
+                              key={`${row.label}-${row.value}`}
+                              className="text-sm"
+                            >
+                              <span className="font-medium text-foreground">
+                                {row.label}:{" "}
+                              </span>
+                              <span className="text-muted-foreground break-words">
+                                {row.value}
+                              </span>
+                            </div>
+                          ))}
                         </div>
                       </TableCell>
                     </TableRow>
@@ -728,15 +970,22 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
         {logs.map((log) => {
           const changes = log.metadata?.changes || {};
           const keyName = log.metadata?.key_name;
+          const effectiveAction = getEffectiveAction(log);
           const changeEntries = Object.entries(changes);
-          const canExpand = changeEntries.length > 0;
+          const transferDetailRows = getTransferDetailRows(
+            effectiveAction,
+            log.metadata,
+          );
+          const canExpand =
+            changeEntries.length > 0 || transferDetailRows.length > 0;
           const isExpanded = expandedRows.has(log.id);
           const affectedUser = getBeneficiaryLabel(log.metadata);
-          const effectiveAction = getEffectiveAction(log);
           const actionText = getActionLabel(effectiveAction);
           const detailsSummary =
             getNonDiffContextSummary(effectiveAction, log.metadata, keyName) ||
-            (!canExpand ? getDetailSummary(changeEntries, keyName) : null);
+            (changeEntries.length === 0
+              ? getDetailSummary(changeEntries, keyName)
+              : null);
           const shouldShowAffectedUser =
             isMemberRelatedAction(effectiveAction) && Boolean(affectedUser);
 
@@ -750,7 +999,9 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                   {canExpand ? (
                     <button
                       type="button"
-                      aria-label={isExpanded ? "Collapse diff" : "Expand diff"}
+                      aria-label={
+                        isExpanded ? "Collapse details" : "Expand details"
+                      }
                       onClick={() => toggleRow(log.id)}
                       className="inline-flex h-7 w-7 items-center justify-center rounded-md hover:bg-muted"
                     >
@@ -814,7 +1065,7 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                   )}
                   {detailsSummary ? <div>{detailsSummary}</div> : null}
                   {!detailsSummary && canExpand ? (
-                    <div>Expand row to view changes</div>
+                    <div>Expand row to view details</div>
                   ) : null}
                 </div>
               )}
@@ -845,6 +1096,19 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                           </span>
                         </>
                       )}
+                    </div>
+                  ))}
+                  {transferDetailRows.map((row) => (
+                    <div
+                      key={`${row.label}-${row.value}`}
+                      className="text-sm"
+                    >
+                      <span className="font-medium text-foreground">
+                        {row.label}:{" "}
+                      </span>
+                      <span className="text-muted-foreground break-words">
+                        {row.value}
+                      </span>
                     </div>
                   ))}
                 </div>

--- a/src/components/dashboard/project-card.tsx
+++ b/src/components/dashboard/project-card.tsx
@@ -49,6 +49,7 @@ import { deleteProject as deleteProjectAction } from "@/app/project-actions";
 
 import { ShareProjectDialog } from "@/components/dashboard/share-project-dialog";
 import { RenameProjectDialog } from "@/components/dashboard/rename-project-dialog";
+import { TransferOwnershipDialog } from "@/components/dashboard/transfer-ownership-dialog";
 import { Share2 } from "lucide-react";
 import { Kbd } from "@/components/ui/kbd";
 
@@ -68,6 +69,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
   const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = React.useState(false);
+  const [transferDialogOpen, setTransferDialogOpen] = React.useState(false);
   const [deleteConfirmation, setDeleteConfirmation] = React.useState("");
   const [isDeleting, setIsDeleting] = React.useState(false);
   const router = useRouter();
@@ -310,6 +312,22 @@ export function ProjectCard({ project }: ProjectCardProps) {
               placeholder={project.name}
               className="bg-background"
             />
+            {project.role === "owner" && (
+              <p className="text-xs text-muted-foreground">
+                Prefer not to delete?{" "}
+                <button
+                  type="button"
+                  className="underline underline-offset-2 text-foreground hover:text-primary transition-colors"
+                  onClick={() => {
+                    setDeleteDialogOpen(false);
+                    setTransferDialogOpen(true);
+                  }}
+                >
+                  Transfer ownership instead
+                </button>
+                .
+              </p>
+            )}
           </div>
 
           <AlertDialogFooter>
@@ -352,6 +370,11 @@ export function ProjectCard({ project }: ProjectCardProps) {
         project={project}
         open={renameDialogOpen}
         onOpenChange={setRenameDialogOpen}
+      />
+      <TransferOwnershipDialog
+        project={project}
+        open={transferDialogOpen}
+        onOpenChange={setTransferDialogOpen}
       />
     </>
   );

--- a/src/components/dashboard/transfer-ownership-dialog.tsx
+++ b/src/components/dashboard/transfer-ownership-dialog.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import * as React from "react";
+import { ArrowRightLeft, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Project } from "@/lib/store";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface TransferOwnershipDialogProps {
+  project: Project;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function TransferOwnershipDialog({
+  project,
+  open,
+  onOpenChange,
+}: TransferOwnershipDialogProps) {
+  const [target, setTarget] = React.useState("");
+  const [ownerAction, setOwnerAction] = React.useState<
+    "demote_to_editor" | "remove_from_project"
+  >("demote_to_editor");
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!open) {
+      setTarget("");
+      setOwnerAction("demote_to_editor");
+      setIsSubmitting(false);
+    }
+  }, [open]);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const trimmedTarget = target.trim();
+    if (!trimmedTarget) {
+      toast.error("Enter the target user email or user ID.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    const isEmail = trimmedTarget.includes("@");
+    const payload = {
+      currentOwnerAction: ownerAction,
+      ...(isEmail
+        ? { targetEmail: trimmedTarget }
+        : { targetUserId: trimmedTarget }),
+    };
+
+    try {
+      const response = await fetch(
+        `/api/projects/${project.id}/transfer/initiate`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        },
+      );
+
+      const data = (await response.json().catch(() => ({}))) as {
+        error?: string;
+        request?: { expiresAt?: string };
+      };
+
+      if (!response.ok) {
+        toast.error(data.error || "Failed to initiate ownership transfer.");
+        return;
+      }
+
+      const expiresAt = data.request?.expiresAt
+        ? new Date(data.request.expiresAt).toLocaleString()
+        : "48 hours";
+
+      toast.success(`Transfer request sent. It expires on ${expiresAt}.`);
+      onOpenChange(false);
+    } catch (error) {
+      console.error("[transfer-ownership] request failed", error);
+      toast.error("Failed to initiate ownership transfer.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[95vw] max-w-lg sm:w-full">
+        <DialogHeader>
+          <DialogTitle>Transfer Ownership</DialogTitle>
+          <DialogDescription>
+            Ownership transfer requires recipient consent. The target user must
+            explicitly accept before ownership changes.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="transfer-target">Target User</Label>
+            <Input
+              id="transfer-target"
+              value={target}
+              onChange={(event) => setTarget(event.target.value)}
+              placeholder="email@example.com or user UUID"
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>After Transfer, My Access</Label>
+            <Select
+              value={ownerAction}
+              onValueChange={(
+                value: "demote_to_editor" | "remove_from_project",
+              ) => setOwnerAction(value)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="demote_to_editor">
+                  Demote me to Editor
+                </SelectItem>
+                <SelectItem value="remove_from_project">
+                  Remove me from project
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting || !target.trim()}>
+              {isSubmitting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <ArrowRightLeft className="h-4 w-4" />
+              )}
+              Request Transfer
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/editor/project-detail-view.tsx
+++ b/src/components/editor/project-detail-view.tsx
@@ -14,6 +14,7 @@ import {
   Copy,
   Check,
   Info,
+  ArrowRightLeft,
 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -59,6 +60,7 @@ import { createAccessRequest } from "@/app/invite-actions";
 import { ShareProjectDialog } from "@/components/dashboard/share-project-dialog";
 import { RenameProjectDialog } from "@/components/dashboard/rename-project-dialog";
 import { GitHubIntegrationDialog } from "@/components/dashboard/github-integration-dialog";
+import { TransferOwnershipDialog } from "@/components/dashboard/transfer-ownership-dialog";
 import { AppHeader } from "@/components/dashboard/app-header";
 import { Edit3, Github, Loader2, ShieldCheck } from "lucide-react";
 import { formatEnvironmentLabel } from "@/lib/environment-label";
@@ -82,6 +84,7 @@ export default function ProjectDetailView({ project }: ProjectDetailViewProps) {
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [githubDialogOpen, setGithubDialogOpen] = useState(false);
+  const [transferDialogOpen, setTransferDialogOpen] = useState(false);
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
   const [deleteConfirmation, setDeleteConfirmation] = useState("");
@@ -337,6 +340,11 @@ export default function ProjectDetailView({ project }: ProjectDetailViewProps) {
               </DropdownMenuItem>
             )}
             {project.role === "owner" && (
+              <DropdownMenuItem onClick={() => setTransferDialogOpen(true)}>
+                <ArrowRightLeft className="w-4 h-4 mr-2" /> Transfer Ownership
+              </DropdownMenuItem>
+            )}
+            {project.role === "owner" && (
               <DropdownMenuItem onClick={() => setGithubDialogOpen(true)}>
                 <Github className="w-4 h-4 mr-2" /> GitHub Integration
               </DropdownMenuItem>
@@ -554,6 +562,22 @@ export default function ProjectDetailView({ project }: ProjectDetailViewProps) {
               placeholder={project.name}
               className="bg-background"
             />
+            {project.role === "owner" && (
+              <p className="text-xs text-muted-foreground">
+                Prefer not to delete?{" "}
+                <button
+                  type="button"
+                  className="underline underline-offset-2 text-foreground hover:text-primary transition-colors"
+                  onClick={() => {
+                    setDeleteDialogOpen(false);
+                    setTransferDialogOpen(true);
+                  }}
+                >
+                  Transfer ownership instead
+                </button>
+                .
+              </p>
+            )}
           </div>
 
           <AlertDialogFooter>
@@ -602,6 +626,11 @@ export default function ProjectDetailView({ project }: ProjectDetailViewProps) {
         project={project}
         open={githubDialogOpen}
         onOpenChange={setGithubDialogOpen}
+      />
+      <TransferOwnershipDialog
+        project={project}
+        open={transferDialogOpen}
+        onOpenChange={setTransferDialogOpen}
       />
     </div>
   );

--- a/src/components/landing/GlobalScene.tsx
+++ b/src/components/landing/GlobalScene.tsx
@@ -25,6 +25,7 @@ export function GlobalScene() {
   const isAuthPage =
     pathname?.startsWith("/login") ||
     pathname?.startsWith("/register") ||
+    pathname?.startsWith("/transfer") ||
     pathname?.startsWith("/auth/device") ||
     pathname?.startsWith("/approve");
   const isLandingPage = pathname === "/";

--- a/src/lib/audit-logger.ts
+++ b/src/lib/audit-logger.ts
@@ -18,6 +18,9 @@ export type AuditLogAction =
   | "member.invited"
   | "member.role_updated"
   | "member.removed"
+  | "transfer.requested"
+  | "transfer.accepted"
+  | "transfer.rejected"
   | "environment.access_granted"
   | "environment.access_revoked";
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -678,6 +678,148 @@ export async function sendProjectActivityEmail(
   }
 }
 
+export async function sendOwnershipTransferRequestedEmail(
+  to: string,
+  projectName: string,
+  requestedBy: string,
+  requestId: string,
+  userId?: string,
+) {
+  if (process.env.NODE_ENV === "development" && !process.env.RESEND_API_KEY) {
+    console.log("Skipping ownership transfer request email in DEV.");
+    return;
+  }
+
+  if (userId) {
+    const { createAdminClient } = await import("@/lib/supabase/admin");
+    const admin = createAdminClient();
+    const { data: prefs } = await admin
+      .from("notification_preferences")
+      .select("email_access_requests")
+      .eq("user_id", userId)
+      .single();
+
+    if (prefs && prefs.email_access_requests === false) {
+      return;
+    }
+  }
+
+  try {
+    const html = getEmailHtml({
+      heading: "Ownership Transfer Requested",
+      content: `<p><strong>${requestedBy}</strong> requested to transfer ownership of <strong>${projectName}</strong> to you.</p><p>Review and accept/reject from the project transfer controls in Envault.</p>`,
+      action: {
+        text: "Review Transfer Request",
+        url: `${APP_URL}/transfer/${requestId}`,
+      },
+      logoUrl: LOGO_URL,
+    });
+
+    await resend.emails.send({
+      from: SENDERS.activity,
+      to,
+      subject: `Ownership Transfer Request: ${projectName}`,
+      html,
+    });
+  } catch (error) {
+    console.error("Failed to send ownership transfer request email:", error);
+  }
+}
+
+export async function sendOwnershipTransferAcceptedEmail(
+  to: string,
+  projectName: string,
+  acceptedBy: string,
+  userId?: string,
+) {
+  if (process.env.NODE_ENV === "development" && !process.env.RESEND_API_KEY) {
+    console.log("Skipping ownership transfer accepted email in DEV.");
+    return;
+  }
+
+  if (userId) {
+    const { createAdminClient } = await import("@/lib/supabase/admin");
+    const admin = createAdminClient();
+    const { data: prefs } = await admin
+      .from("notification_preferences")
+      .select("email_access_granted")
+      .eq("user_id", userId)
+      .single();
+
+    if (prefs && prefs.email_access_granted === false) {
+      return;
+    }
+  }
+
+  try {
+    const html = getEmailHtml({
+      heading: "Ownership Transfer Accepted",
+      content: `<p><strong>${acceptedBy}</strong> accepted ownership transfer for <strong>${projectName}</strong>.</p>`,
+      action: {
+        text: "Go to Dashboard",
+        url: `${APP_URL}/dashboard`,
+      },
+      logoUrl: LOGO_URL,
+    });
+
+    await resend.emails.send({
+      from: SENDERS.activity,
+      to,
+      subject: `Ownership Transfer Accepted: ${projectName}`,
+      html,
+    });
+  } catch (error) {
+    console.error("Failed to send ownership transfer accepted email:", error);
+  }
+}
+
+export async function sendOwnershipTransferRejectedEmail(
+  to: string,
+  projectName: string,
+  rejectedBy: string,
+  userId?: string,
+) {
+  if (process.env.NODE_ENV === "development" && !process.env.RESEND_API_KEY) {
+    console.log("Skipping ownership transfer rejected email in DEV.");
+    return;
+  }
+
+  if (userId) {
+    const { createAdminClient } = await import("@/lib/supabase/admin");
+    const admin = createAdminClient();
+    const { data: prefs } = await admin
+      .from("notification_preferences")
+      .select("email_access_granted")
+      .eq("user_id", userId)
+      .single();
+
+    if (prefs && prefs.email_access_granted === false) {
+      return;
+    }
+  }
+
+  try {
+    const html = getEmailHtml({
+      heading: "Ownership Transfer Rejected",
+      content: `<p><strong>${rejectedBy}</strong> rejected ownership transfer for <strong>${projectName}</strong>.</p>`,
+      action: {
+        text: "Go to Dashboard",
+        url: `${APP_URL}/dashboard`,
+      },
+      logoUrl: LOGO_URL,
+    });
+
+    await resend.emails.send({
+      from: SENDERS.activity,
+      to,
+      subject: `Ownership Transfer Rejected: ${projectName}`,
+      html,
+    });
+  } catch (error) {
+    console.error("Failed to send ownership transfer rejected email:", error);
+  }
+}
+
 // ============================================
 // CLI ACTIVITY EMAILS
 // ============================================

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -112,6 +112,9 @@ async function shouldCreateNotification(
     case "project_created":
     case "project_renamed":
     case "project_deleted":
+    case "ownership_transfer_requested":
+    case "ownership_transfer_accepted":
+    case "ownership_transfer_rejected":
     case "settings_changed":
     case "member_joined":
     case "member_left":
@@ -484,6 +487,80 @@ export async function createProjectDeletedNotification(
       projectName,
       deletedBy,
     },
+  });
+}
+
+/**
+ * Create an ownership transfer requested notification (target user).
+ */
+export async function createOwnershipTransferRequestedNotification(
+  userId: string,
+  projectName: string,
+  projectId: string,
+  requestedBy: string,
+  requestId: string,
+) {
+  return createNotification({
+    userId,
+    type: "ownership_transfer_requested",
+    title: "Ownership Transfer Requested",
+    message: `${requestedBy} requested to transfer ownership of ${projectName} to you.`,
+    variant: "warning",
+    metadata: {
+      projectId,
+      requestId,
+      requestedBy,
+    },
+    actionUrl: `/transfer/${requestId}`,
+    actionType: "review_transfer",
+  });
+}
+
+/**
+ * Create an ownership transfer accepted notification (previous owner).
+ */
+export async function createOwnershipTransferAcceptedNotification(
+  userId: string,
+  projectName: string,
+  projectId: string,
+  acceptedBy: string,
+) {
+  return createNotification({
+    userId,
+    type: "ownership_transfer_accepted",
+    title: "Ownership Transfer Accepted",
+    message: `${acceptedBy} accepted ownership transfer for ${projectName}.`,
+    variant: "success",
+    metadata: {
+      projectId,
+      acceptedBy,
+    },
+    actionUrl: "/dashboard",
+    actionType: "view_dashboard",
+  });
+}
+
+/**
+ * Create an ownership transfer rejected notification (previous owner).
+ */
+export async function createOwnershipTransferRejectedNotification(
+  userId: string,
+  projectName: string,
+  projectId: string,
+  rejectedBy: string,
+) {
+  return createNotification({
+    userId,
+    type: "ownership_transfer_rejected",
+    title: "Ownership Transfer Rejected",
+    message: `${rejectedBy} rejected ownership transfer for ${projectName}.`,
+    variant: "warning",
+    metadata: {
+      projectId,
+      rejectedBy,
+    },
+    actionUrl: "/dashboard",
+    actionType: "view_dashboard",
   });
 }
 

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -41,6 +41,14 @@ export const writeRateLimit = new Ratelimit({
   prefix: "@upstash/ratelimit/write",
 });
 
+// Ownership transfer actions: lower-frequency, high-impact mutations
+export const transferRateLimit = new Ratelimit({
+  redis: getRedisClient(),
+  limiter: Ratelimit.slidingWindow(6, "1 m"),
+  analytics: true,
+  prefix: "@upstash/ratelimit/transfer",
+});
+
 // Audit read: 20/min
 export const auditReadRateLimit = new Ratelimit({
   redis: getRedisClient(),

--- a/src/lib/types/notifications.ts
+++ b/src/lib/types/notifications.ts
@@ -37,6 +37,9 @@ export type NotificationType =
   | "project_created"
   | "project_renamed"
   | "project_deleted"
+  | "ownership_transfer_requested"
+  | "ownership_transfer_accepted"
+  | "ownership_transfer_rejected"
   | "settings_changed"
   // CLI Activity
   | "secrets_pulled"
@@ -110,6 +113,9 @@ export const NOTIFICATION_ICONS: Record<NotificationType, string> = {
   project_created: "FolderPlus",
   project_renamed: "FileEdit",
   project_deleted: "FolderX",
+  ownership_transfer_requested: "ArrowRightLeft",
+  ownership_transfer_accepted: "ArrowRightLeft",
+  ownership_transfer_rejected: "ArrowRightLeft",
   settings_changed: "Settings",
   // CLI Activity
   secrets_pulled: "Download",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -30,12 +30,17 @@ export async function proxy(request: NextRequest) {
   }
 
   const isCliApiRoute = matchesRoute(pathname, "/api/cli");
+  const isTransferApiRoute =
+    /^\/api\/projects\/[^/]+\/transfer\/(initiate|accept|reject)$/.test(
+      pathname,
+    );
 
   // Explicit unauthenticated API allowlist.
   const unauthenticatedApiRoutes = [
     "/api/system-status",
     "/api/cli-version",
     "/api/search",
+    "/api/avatar",
     "/api/cli/auth/device/code",
     "/api/cli/auth/device/token",
     "/api/cli/auth/device/cancel",
@@ -57,7 +62,8 @@ export async function proxy(request: NextRequest) {
   if (
     ["POST", "PUT", "PATCH", "DELETE"].includes(method) &&
     !isPublicApi &&
-    !isCliBearerRequest
+    !isCliBearerRequest &&
+    !isTransferApiRoute
   ) {
     const signature = request.headers.get("x-signature");
     const timestampStr = request.headers.get("x-timestamp");

--- a/supabase/migrations/20260316170000_add_project_transfer_requests.sql
+++ b/supabase/migrations/20260316170000_add_project_transfer_requests.sql
@@ -1,0 +1,224 @@
+-- Two-step project ownership transfer handshake.
+-- Owners initiate, target users accept/reject, and acceptance executes atomically.
+
+create table if not exists public.project_transfer_requests (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  current_owner_id uuid not null references auth.users(id) on delete cascade,
+  target_user_id uuid not null references auth.users(id) on delete cascade,
+  initiated_by uuid not null references auth.users(id) on delete cascade,
+  current_owner_action text not null default 'demote_to_editor'
+    check (current_owner_action in ('demote_to_editor', 'remove_from_project')),
+  status text not null default 'pending'
+    check (status in ('pending', 'accepted', 'rejected', 'expired')),
+  expires_at timestamptz not null default (timezone('utc'::text, now()) + interval '48 hours'),
+  created_at timestamptz not null default timezone('utc'::text, now()),
+  updated_at timestamptz not null default timezone('utc'::text, now()),
+  responded_at timestamptz,
+
+  constraint project_transfer_requests_target_not_owner
+    check (current_owner_id <> target_user_id)
+);
+
+-- Prevent overlapping pending transfers for the same project.
+create unique index if not exists uq_project_transfer_pending_per_project
+  on public.project_transfer_requests(project_id)
+  where status = 'pending';
+
+create index if not exists idx_project_transfer_target_status
+  on public.project_transfer_requests(target_user_id, status, expires_at desc);
+
+create index if not exists idx_project_transfer_project_status
+  on public.project_transfer_requests(project_id, status, created_at desc);
+
+create or replace function public.set_project_transfer_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := timezone('utc'::text, now());
+  return new;
+end;
+$$;
+
+DROP TRIGGER IF EXISTS trg_project_transfer_updated_at ON public.project_transfer_requests;
+create trigger trg_project_transfer_updated_at
+before update on public.project_transfer_requests
+for each row execute function public.set_project_transfer_updated_at();
+
+alter table public.project_transfer_requests enable row level security;
+
+-- Owner and target can view their own transfer records.
+drop policy if exists "project_transfer_requests_select_policy" on public.project_transfer_requests;
+create policy "project_transfer_requests_select_policy"
+  on public.project_transfer_requests for select
+  to authenticated
+  using (
+    initiated_by = (select auth.uid())
+    or target_user_id = (select auth.uid())
+    or public.user_owns_project(project_id, (select auth.uid()))
+  );
+
+-- Inserts are restricted to the current owner initiating for their project.
+drop policy if exists "project_transfer_requests_insert_policy" on public.project_transfer_requests;
+create policy "project_transfer_requests_insert_policy"
+  on public.project_transfer_requests for insert
+  to authenticated
+  with check (
+    initiated_by = (select auth.uid())
+    and current_owner_id = (select auth.uid())
+    and public.user_owns_project(project_id, (select auth.uid()))
+  );
+
+-- Updates/deletes are blocked for authenticated clients; server-side uses service role.
+
+-- Transactional acceptance path.
+create or replace function public.execute_project_transfer(
+  p_transfer_request_id uuid,
+  p_project_id uuid,
+  p_actor_user_id uuid
+)
+returns table (
+  previous_owner_id uuid,
+  new_owner_id uuid,
+  owner_action text,
+  transferred_secret_count bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_request public.project_transfer_requests%rowtype;
+  v_project public.projects%rowtype;
+  v_secret_count bigint := 0;
+begin
+  if p_transfer_request_id is null or p_project_id is null or p_actor_user_id is null then
+    raise exception 'invalid_transfer_args';
+  end if;
+
+  -- Lock request row.
+  select *
+  into v_request
+  from public.project_transfer_requests
+  where id = p_transfer_request_id
+    and project_id = p_project_id
+  for update;
+
+  if not found then
+    raise exception 'transfer_request_not_found';
+  end if;
+
+  if v_request.status <> 'pending' then
+    raise exception 'transfer_request_not_pending';
+  end if;
+
+  if v_request.expires_at <= timezone('utc'::text, now()) then
+    update public.project_transfer_requests
+    set status = 'expired',
+        responded_at = timezone('utc'::text, now())
+    where id = v_request.id;
+
+    raise exception 'transfer_request_expired';
+  end if;
+
+  if v_request.target_user_id <> p_actor_user_id then
+    raise exception 'transfer_request_target_mismatch';
+  end if;
+
+  -- Lock project row.
+  select *
+  into v_project
+  from public.projects
+  where id = p_project_id
+  for update;
+
+  if not found then
+    raise exception 'project_not_found';
+  end if;
+
+  if v_project.user_id <> v_request.current_owner_id then
+    raise exception 'project_owner_changed';
+  end if;
+
+  -- Promote target to owner.
+  update public.projects
+  set user_id = v_request.target_user_id,
+      last_updated_at = timezone('utc'::text, now())
+  where id = p_project_id;
+
+  -- Remove target from members table if present (owner should not be a member).
+  delete from public.project_members
+  where project_id = p_project_id
+    and user_id = v_request.target_user_id;
+
+  -- Demote or remove original owner.
+  if v_request.current_owner_action = 'remove_from_project' then
+    delete from public.project_members
+    where project_id = p_project_id
+      and user_id = v_request.current_owner_id;
+  else
+    insert into public.project_members (project_id, user_id, role, added_by, allowed_environments)
+    values (p_project_id, v_request.current_owner_id, 'editor', v_request.target_user_id, null)
+    on conflict (project_id, user_id)
+    do update
+      set role = 'editor',
+          added_by = excluded.added_by,
+          allowed_environments = null;
+  end if;
+
+  -- Transfer liability of all secrets (including legacy/orphaned ownership rows) to new owner.
+  update public.secrets
+  set user_id = v_request.target_user_id,
+      last_updated_by = v_request.target_user_id,
+      last_updated_by_user_id_snapshot = v_request.target_user_id,
+      last_updated_at = timezone('utc'::text, now())
+  where project_id = p_project_id;
+
+  get diagnostics v_secret_count = row_count;
+
+  -- Mark accepted for traceability, then remove pending record per business rule.
+  update public.project_transfer_requests
+  set status = 'accepted',
+      responded_at = timezone('utc'::text, now())
+  where id = v_request.id;
+
+  delete from public.project_transfer_requests
+  where id = v_request.id;
+
+  return query
+  select
+    v_request.current_owner_id,
+    v_request.target_user_id,
+    v_request.current_owner_action,
+    v_secret_count;
+end;
+$$;
+
+revoke all on function public.execute_project_transfer(uuid, uuid, uuid) from public;
+revoke all on function public.execute_project_transfer(uuid, uuid, uuid) from anon;
+revoke all on function public.execute_project_transfer(uuid, uuid, uuid) from authenticated;
+grant execute on function public.execute_project_transfer(uuid, uuid, uuid) to service_role;
+
+-- Expire stale pending transfers every 15 minutes.
+create extension if not exists pg_cron;
+
+do $$
+begin
+  perform cron.unschedule('project_transfer_expiration');
+exception
+  when others then
+    null;
+end $$;
+
+select cron.schedule(
+  'project_transfer_expiration',
+  '*/15 * * * *',
+  $$
+    update public.project_transfer_requests
+    set status = 'expired',
+        responded_at = timezone('utc'::text, now())
+    where status = 'pending'
+      and expires_at <= timezone('utc'::text, now());
+  $$
+);

--- a/supabase/migrations/20260316183000_fix_transfer_lint_advisories.sql
+++ b/supabase/migrations/20260316183000_fix_transfer_lint_advisories.sql
@@ -1,0 +1,20 @@
+-- Address linter findings for ownership transfer objects.
+
+-- 1) SECURITY: function_search_path_mutable
+create or replace function public.set_project_transfer_updated_at()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  new.updated_at := timezone('utc'::text, now());
+  return new;
+end;
+$$;
+
+-- 2) PERFORMANCE: unindexed foreign keys on project_transfer_requests
+create index if not exists idx_project_transfer_current_owner_id
+  on public.project_transfer_requests(current_owner_id);
+
+create index if not exists idx_project_transfer_initiated_by
+  on public.project_transfer_requests(initiated_by);

--- a/supabase/migrations/20260316190000_fix_transfer_projects_last_updated_at.sql
+++ b/supabase/migrations/20260316190000_fix_transfer_projects_last_updated_at.sql
@@ -1,0 +1,122 @@
+-- Fix compatibility: some deployments do not have projects.last_updated_at.
+-- Recreate transfer function without referencing that column.
+
+create or replace function public.execute_project_transfer(
+  p_transfer_request_id uuid,
+  p_project_id uuid,
+  p_actor_user_id uuid
+)
+returns table (
+  previous_owner_id uuid,
+  new_owner_id uuid,
+  owner_action text,
+  transferred_secret_count bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_request public.project_transfer_requests%rowtype;
+  v_project public.projects%rowtype;
+  v_secret_count bigint := 0;
+begin
+  if p_transfer_request_id is null or p_project_id is null or p_actor_user_id is null then
+    raise exception 'invalid_transfer_args';
+  end if;
+
+  select *
+  into v_request
+  from public.project_transfer_requests
+  where id = p_transfer_request_id
+    and project_id = p_project_id
+  for update;
+
+  if not found then
+    raise exception 'transfer_request_not_found';
+  end if;
+
+  if v_request.status <> 'pending' then
+    raise exception 'transfer_request_not_pending';
+  end if;
+
+  if v_request.expires_at <= timezone('utc'::text, now()) then
+    update public.project_transfer_requests
+    set status = 'expired',
+        responded_at = timezone('utc'::text, now())
+    where id = v_request.id;
+
+    raise exception 'transfer_request_expired';
+  end if;
+
+  if v_request.target_user_id <> p_actor_user_id then
+    raise exception 'transfer_request_target_mismatch';
+  end if;
+
+  select *
+  into v_project
+  from public.projects
+  where id = p_project_id
+  for update;
+
+  if not found then
+    raise exception 'project_not_found';
+  end if;
+
+  if v_project.user_id <> v_request.current_owner_id then
+    raise exception 'project_owner_changed';
+  end if;
+
+  -- Promote target to owner.
+  update public.projects
+  set user_id = v_request.target_user_id
+  where id = p_project_id;
+
+  delete from public.project_members
+  where project_id = p_project_id
+    and user_id = v_request.target_user_id;
+
+  if v_request.current_owner_action = 'remove_from_project' then
+    delete from public.project_members
+    where project_id = p_project_id
+      and user_id = v_request.current_owner_id;
+  else
+    insert into public.project_members (project_id, user_id, role, added_by, allowed_environments)
+    values (p_project_id, v_request.current_owner_id, 'editor', v_request.target_user_id, null)
+    on conflict (project_id, user_id)
+    do update
+      set role = 'editor',
+          added_by = excluded.added_by,
+          allowed_environments = null;
+  end if;
+
+  update public.secrets
+  set user_id = v_request.target_user_id,
+      last_updated_by = v_request.target_user_id,
+      last_updated_by_user_id_snapshot = v_request.target_user_id,
+      last_updated_at = timezone('utc'::text, now())
+  where project_id = p_project_id;
+
+  get diagnostics v_secret_count = row_count;
+
+  update public.project_transfer_requests
+  set status = 'accepted',
+      responded_at = timezone('utc'::text, now())
+  where id = v_request.id;
+
+  delete from public.project_transfer_requests
+  where id = v_request.id;
+
+  return query
+  select
+    v_request.current_owner_id,
+    v_request.target_user_id,
+    v_request.current_owner_action,
+    v_secret_count;
+end;
+$$;
+
+revoke all on function public.execute_project_transfer(uuid, uuid, uuid) from public;
+revoke all on function public.execute_project_transfer(uuid, uuid, uuid) from anon;
+revoke all on function public.execute_project_transfer(uuid, uuid, uuid) from authenticated;
+grant execute on function public.execute_project_transfer(uuid, uuid, uuid) to service_role;

--- a/supabase/migrations/20260316193000_fix_transfer_preserve_last_updated_identity.sql
+++ b/supabase/migrations/20260316193000_fix_transfer_preserve_last_updated_identity.sql
@@ -1,0 +1,120 @@
+-- Preserve secret edit history on ownership transfer.
+-- Liability should move to new owner via secrets.user_id, but last_updated_by
+-- and identity snapshots must remain tied to the real last editor.
+
+create or replace function public.execute_project_transfer(
+  p_transfer_request_id uuid,
+  p_project_id uuid,
+  p_actor_user_id uuid
+)
+returns table (
+  previous_owner_id uuid,
+  new_owner_id uuid,
+  owner_action text,
+  transferred_secret_count bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_request public.project_transfer_requests%rowtype;
+  v_project public.projects%rowtype;
+  v_secret_count bigint := 0;
+begin
+  if p_transfer_request_id is null or p_project_id is null or p_actor_user_id is null then
+    raise exception 'invalid_transfer_args';
+  end if;
+
+  select *
+  into v_request
+  from public.project_transfer_requests
+  where id = p_transfer_request_id
+    and project_id = p_project_id
+  for update;
+
+  if not found then
+    raise exception 'transfer_request_not_found';
+  end if;
+
+  if v_request.status <> 'pending' then
+    raise exception 'transfer_request_not_pending';
+  end if;
+
+  if v_request.expires_at <= timezone('utc'::text, now()) then
+    update public.project_transfer_requests
+    set status = 'expired',
+        responded_at = timezone('utc'::text, now())
+    where id = v_request.id;
+
+    raise exception 'transfer_request_expired';
+  end if;
+
+  if v_request.target_user_id <> p_actor_user_id then
+    raise exception 'transfer_request_target_mismatch';
+  end if;
+
+  select *
+  into v_project
+  from public.projects
+  where id = p_project_id
+  for update;
+
+  if not found then
+    raise exception 'project_not_found';
+  end if;
+
+  if v_project.user_id <> v_request.current_owner_id then
+    raise exception 'project_owner_changed';
+  end if;
+
+  update public.projects
+  set user_id = v_request.target_user_id
+  where id = p_project_id;
+
+  delete from public.project_members
+  where project_id = p_project_id
+    and user_id = v_request.target_user_id;
+
+  if v_request.current_owner_action = 'remove_from_project' then
+    delete from public.project_members
+    where project_id = p_project_id
+      and user_id = v_request.current_owner_id;
+  else
+    insert into public.project_members (project_id, user_id, role, added_by, allowed_environments)
+    values (p_project_id, v_request.current_owner_id, 'editor', v_request.target_user_id, null)
+    on conflict (project_id, user_id)
+    do update
+      set role = 'editor',
+          added_by = excluded.added_by,
+          allowed_environments = null;
+  end if;
+
+  -- Transfer liability only; preserve edit-attribution fields.
+  update public.secrets
+  set user_id = v_request.target_user_id
+  where project_id = p_project_id;
+
+  get diagnostics v_secret_count = row_count;
+
+  update public.project_transfer_requests
+  set status = 'accepted',
+      responded_at = timezone('utc'::text, now())
+  where id = v_request.id;
+
+  delete from public.project_transfer_requests
+  where id = v_request.id;
+
+  return query
+  select
+    v_request.current_owner_id,
+    v_request.target_user_id,
+    v_request.current_owner_action,
+    v_secret_count;
+end;
+$$;
+
+revoke all on function public.execute_project_transfer(uuid, uuid, uuid) from public;
+revoke all on function public.execute_project_transfer(uuid, uuid, uuid) from anon;
+revoke all on function public.execute_project_transfer(uuid, uuid, uuid) from authenticated;
+grant execute on function public.execute_project_transfer(uuid, uuid, uuid) to service_role;


### PR DESCRIPTION
## Summary
- implement two-step project ownership transfer (`initiate`, `accept`, `reject`) with pending request state and 48h expiry
- add transactional transfer execution with owner promotion, prior-owner demotion/removal, and secret liability reassignment
- add transfer notifications (email + in-app), proxy/rate-limit wiring, and transfer accept/reject UI flow
- enrich transfer audit metadata and improve audit log presentation (badges, structured details, consistent summary)
- preserve last-editor attribution during transfer and fix identity consistency in variable Last Updated display
- add delete-dialog inline alternative to transfer ownership (project card + project view)
- update docs across core/API for transfer behavior and UX

## Validation
- `npm run lint`

## Notes
- includes migration fixes for lint advisories and transfer function compatibility/history handling
