### PR TITLE
chore: migrate local dev from ngrok/localhost to portless https

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,16 @@ For more details, check out the [CLI Documentation](./cli-go/README.md).
 
 ### Local Testing
 
-To use the Envault CLI with a local development server, set the `ENVAULT_CLI_URL` environment variable:
+Envault local development now uses `portless` with HTTPS hostnames.
 
 ```bash
-export ENVAULT_CLI_URL="http://localhost:3000/api/cli"
+npm install -g portless
+```
+
+To use the Envault CLI with the local development server, set the `ENVAULT_CLI_URL` environment variable:
+
+```bash
+export ENVAULT_CLI_URL="https://envault.localhost/api/cli"
 envault login
 ```
 
@@ -140,7 +146,7 @@ Follow these steps to get the project running locally.
     npm run dev
     ```
 
-    Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+    Open [https://envault.localhost](https://envault.localhost) with your browser to see the result.
 
 5.  **Test Email Configuration (Optional)**
 

--- a/cli-go/cmd/root_test.go
+++ b/cli-go/cmd/root_test.go
@@ -86,7 +86,7 @@ func TestRunCmd_NoConfigLeakOnStdout(t *testing.T) {
 	srv := httptest.NewTLSServer(nil) // just as anchor; we override URL
 	srv.Close()
 
-	// Stand up a plain HTTP server (the CLI allows http for localhost).
+	// Stand up a plain HTTP server for subprocess tests (explicitly allowed via ENVAULT_ALLOW_INSECURE_HTTP).
 	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/secrets") {
 			w.Header().Set("Content-Type", "application/json")
@@ -107,6 +107,7 @@ func TestRunCmd_NoConfigLeakOnStdout(t *testing.T) {
 	cmd.Env = append(os.Environ(),
 		"ENVAULT_CLI_URL="+mockSrv.URL+"/api/cli",
 		"ENVAULT_TOKEN=test-token",
+		"ENVAULT_ALLOW_INSECURE_HTTP=1",
 	)
 
 	var outBuf, errBuf bytes.Buffer
@@ -166,6 +167,7 @@ func TestErrorsRouteToStderr_RunFailed(t *testing.T) {
 	cmd.Env = append(os.Environ(),
 		"ENVAULT_CLI_URL="+mockSrv.URL+"/api/cli",
 		"ENVAULT_TOKEN=test-token",
+		"ENVAULT_ALLOW_INSECURE_HTTP=1",
 	)
 
 	var outBuf, errBuf bytes.Buffer
@@ -204,6 +206,7 @@ func TestPullCmd_NoLeftoverTempFile(t *testing.T) {
 	cmd.Env = append(os.Environ(),
 		"ENVAULT_CLI_URL="+mockSrv.URL+"/api/cli",
 		"ENVAULT_TOKEN=test-token",
+		"ENVAULT_ALLOW_INSECURE_HTTP=1",
 	)
 	var errBuf bytes.Buffer
 	cmd.Stderr = &errBuf
@@ -238,6 +241,7 @@ func TestPullCmd_SecretWrittenToEnvFile(t *testing.T) {
 	cmd.Env = append(os.Environ(),
 		"ENVAULT_CLI_URL="+mockSrv.URL+"/api/cli",
 		"ENVAULT_TOKEN=test-token",
+		"ENVAULT_ALLOW_INSECURE_HTTP=1",
 	)
 	_ = cmd.Run()
 
@@ -275,6 +279,7 @@ func TestPullCmd_SIGINTExitsWithCode130(t *testing.T) {
 	cmd.Env = append(os.Environ(),
 		"ENVAULT_CLI_URL="+slowSrv.URL+"/api/cli",
 		"ENVAULT_TOKEN=test-token",
+		"ENVAULT_ALLOW_INSECURE_HTTP=1",
 	)
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
@@ -341,6 +346,7 @@ func TestDeployCmd_SIGINTExitsWithCode130(t *testing.T) {
 	cmd.Env = append(os.Environ(),
 		"ENVAULT_CLI_URL="+slowSrv.URL+"/api/cli",
 		"ENVAULT_TOKEN=test-token",
+		"ENVAULT_ALLOW_INSECURE_HTTP=1",
 	)
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
@@ -401,6 +407,7 @@ func TestRunCmd_PropagatesChildExitCode(t *testing.T) {
 	cmd.Env = append(os.Environ(),
 		"ENVAULT_CLI_URL="+mockSrv.URL+"/api/cli",
 		"ENVAULT_TOKEN=test-token",
+		"ENVAULT_ALLOW_INSECURE_HTTP=1",
 	)
 
 	err := cmd.Run()
@@ -434,6 +441,7 @@ func TestRunCmd_StdoutIsPureChildOutput(t *testing.T) {
 	cmd.Env = append(os.Environ(),
 		"ENVAULT_CLI_URL="+mockSrv.URL+"/api/cli",
 		"ENVAULT_TOKEN=test-token",
+		"ENVAULT_ALLOW_INSECURE_HTTP=1",
 	)
 
 	var outBuf, errBuf bytes.Buffer

--- a/cli-go/internal/api/client.go
+++ b/cli-go/internal/api/client.go
@@ -45,12 +45,9 @@ func NewClient() *Client {
 		os.Exit(1)
 	}
 
-	hostname := u.Hostname()
-	isLocal := hostname == "localhost" || hostname == "127.0.0.1"
-
-	if !isLocal && u.Scheme != "https" {
-		fmt.Println("Error: Insecure connection (HTTP) is only allowed for localhost.")
-		fmt.Println("       Please use HTTPS for remote servers.")
+	if u.Scheme != "https" && os.Getenv("ENVAULT_ALLOW_INSECURE_HTTP") != "1" {
+		fmt.Println("Error: Insecure connection (HTTP) is not allowed.")
+		fmt.Println("       Please use an HTTPS URL for ENVAULT_CLI_URL.")
 		os.Exit(1)
 	}
 

--- a/content/docs/api/overview.mdx
+++ b/content/docs/api/overview.mdx
@@ -84,7 +84,7 @@ Retrieve all decrypted secrets for a specific project environment.
 ```json
 {
   "secrets": {
-    "DATABASE_URL": "postgres://user:pass@localhost:5432/db",
+    "DATABASE_URL": "postgres://user:pass@db:5432/db",
     "API_KEY": "sk_test_12345",
     "NEXT_PUBLIC_API_URL": "https://api.example.com"
   }

--- a/content/docs/cli/reference.mdx
+++ b/content/docs/cli/reference.mdx
@@ -153,11 +153,11 @@ The Envault CLI uses the following environment variables for configuration:
 To test against a local instance of Envault:
 
 ```bash
-export ENVAULT_CLI_URL="http://localhost:3000/api/cli"
+export ENVAULT_CLI_URL="https://envault.localhost:1355/api/cli"
 envault login
 ```
 
 <Callout type="warn">
-  Insecure (HTTP) connections are only permitted when the hostname is
-  `localhost` or `127.0.0.1`.
+  Insecure `http://` URLs are blocked by default. Use an HTTPS base URL for
+  `ENVAULT_CLI_URL`.
 </Callout>

--- a/content/docs/configuration/environment-variables.mdx
+++ b/content/docs/configuration/environment-variables.mdx
@@ -20,7 +20,7 @@ These environment variables are required to run the Envault server (Next.js app)
 
 | Variable         | Description                                    | Default                  |
 | :--------------- | :--------------------------------------------- | :----------------------- |
-| `REDIS_URL`      | URL for Redis caching.                         | `redis://localhost:6379` |
+| `REDIS_URL`      | URL for Redis caching.                         | `redis://redis:6379`     |
 | `RESEND_API_KEY` | Resend API key for sending application emails. | `re_123456789...`        |
 | `LOG_LEVEL`      | Logging verbosity.                             | `info`                   |
 

--- a/content/docs/guides/initial-setup.mdx
+++ b/content/docs/guides/initial-setup.mdx
@@ -51,10 +51,11 @@ ENCRYPTION_KEY=your_generated_hex_key
 Now you are ready to start the application.
 
 ```bash
+npm install -g portless
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [https://envault.localhost:1355](https://envault.localhost:1355) with your browser to see the result.
 
 ## Email Configuration (Optional)
 

--- a/content/docs/guides/installation.mdx
+++ b/content/docs/guides/installation.mdx
@@ -78,10 +78,11 @@ You will need to populate `.env.local` with your Supabase credentials.
 ### Start Development Server
 
 ```bash
+npm install -g portless
 npm run dev
 ```
 
-Visit `http://localhost:3000` to see your Envault instance running.
+Visit `https://envault.localhost:1355` to see your Envault instance running.
 
 </Step>
 </Steps>

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,7 +12,7 @@ const nextConfig: NextConfig = {
   // Disable it in dev to speed up Turbopack compilation.
   reactCompiler: !isDev,
 
-  allowedDevOrigins: ["lionly-placeable-zina.ngrok-free.dev"],
+  allowedDevOrigins: ["envault.localhost", "*.envault.localhost"],
 
   experimental: {
     // Optimize barrel-file imports so Turbopack only compiles used exports.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next dev --turbo",
+    "dev": "PORTLESS_HTTPS=1 portless run --name envault next dev --turbo",
     "generate:llms": "tsx scripts/generate-llms-full.ts",
     "build": "npm run generate:llms && next build",
     "start": "next start",

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -11,11 +11,12 @@ import { logAuditEvent } from "@/lib/system/audit-logger";
 
 export async function signInWithGoogle(formData?: FormData) {
   const supabase = await createClient();
-  const origin = (await headers()).get("origin");
+  const headersList = await headers();
+  const origin = process.env.NEXT_PUBLIC_APP_URL || headersList.get("origin");
   const next = (formData?.get("next") as string) || "/dashboard";
 
   // Rate Limiting
-  const ip = (await headers()).get("x-forwarded-for") || "unknown";
+  const ip = headersList.get("x-forwarded-for") || "unknown";
   const { success: rateLimitSuccess } = await authRateLimit.limit(ip);
   if (!rateLimitSuccess) {
     return { error: "Too many requests. Please try again later." };
@@ -43,11 +44,12 @@ export async function signInWithGoogle(formData?: FormData) {
 
 export async function signInWithGithub(formData?: FormData) {
   const supabase = await createClient();
-  const origin = (await headers()).get("origin");
+  const headersList = await headers();
+  const origin = process.env.NEXT_PUBLIC_APP_URL || headersList.get("origin");
   const next = (formData?.get("next") as string) || "/dashboard";
 
   // Rate Limiting
-  const ip = (await headers()).get("x-forwarded-for") || "unknown";
+  const ip = headersList.get("x-forwarded-for") || "unknown";
   const { success: rateLimitSuccess } = await authRateLimit.limit(ip);
   if (!rateLimitSuccess) {
     return { error: "Too many requests. Please try again later." };
@@ -107,10 +109,11 @@ export async function signUp(formData: FormData) {
   const email = formData.get("email") as string;
   const password = formData.get("password") as string;
   const supabase = await createClient();
-  const origin = (await headers()).get("origin");
+  const headersList = await headers();
+  const origin = process.env.NEXT_PUBLIC_APP_URL || headersList.get("origin");
 
   // Rate Limiting
-  const ip = (await headers()).get("x-forwarded-for") || "unknown";
+  const ip = headersList.get("x-forwarded-for") || "unknown";
   const { success: rateLimitSuccess } = await authRateLimit.limit(ip);
   if (!rateLimitSuccess) {
     return { error: "Too many requests. Please try again later." };

--- a/src/app/api/project/[projectId]/audit-logs/route.ts
+++ b/src/app/api/project/[projectId]/audit-logs/route.ts
@@ -117,7 +117,7 @@ export async function GET(
     const { projectId } = params;
 
     // Apply Rate Limiting
-    const ip = req.headers.get("x-forwarded-for") || "127.0.0.1";
+    const ip = req.headers.get("x-forwarded-for") || "unknown";
     const { success } = await auditReadRateLimit.limit(`audit_read_${ip}`);
 
     if (!success) {

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
   const code = searchParams.get("code");
   // if "next" is in param, use it as the redirect URL
   const next = searchParams.get("next") ?? "/";
@@ -12,6 +13,9 @@ export async function GET(request: Request) {
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
       const forwardedHost = request.headers.get("x-forwarded-host"); // original origin before load balancer
+      if (appUrl) {
+        return NextResponse.redirect(`${appUrl}${next}`);
+      }
       const isLocalEnv = process.env.NODE_ENV === "development";
       if (isLocalEnv) {
         // we can be sure that there is no load balancer in between, so no need to watch for X-Forwarded-Host

--- a/src/components/landing/sections/CliSection.tsx
+++ b/src/components/landing/sections/CliSection.tsx
@@ -9,11 +9,23 @@ import { SlideUp } from "@/components/landing/animations/SlideUp";
 export async function CliSection() {
   let version: string | null = null;
   try {
-    // Construct the full URL for the API endpoint since Server Components require absolute URLs
+    // In dev with portless, Node SSR cannot always resolve *.localhost hostnames.
+    // Use the internal Next dev server port directly when available.
     const headersList = await headers();
-    const host = headersList.get("host") || "localhost:3000";
-    const protocol = host.includes("localhost") ? "http" : "https";
-    const baseUrl = `${protocol}://${host}`;
+    const internalDevPort =
+      process.env.NODE_ENV === "development" ? process.env.PORT : undefined;
+
+    const host =
+      headersList.get("x-forwarded-host") ||
+      headersList.get("host") ||
+      "envault.tech";
+    const protocol =
+      headersList.get("x-forwarded-proto") ||
+      (host.includes("localhost") ? "http" : "https");
+
+    const baseUrl = internalDevPort
+      ? `http://127.0.0.1:${internalDevPort}`
+      : `${protocol}://${host}`;
 
     const res = await fetch(`${baseUrl}/api/cli-version`, {
       next: { revalidate: 3600 },

--- a/src/lib/auth/webauthn.ts
+++ b/src/lib/auth/webauthn.ts
@@ -1,14 +1,21 @@
 export const rpName = "Envault";
 
+function getForwardedHost(req: Request): string | null {
+  const forwardedHost = req.headers.get("x-forwarded-host");
+  if (!forwardedHost) return null;
+  // In proxy chains this may be a comma-separated list; first hop is client-facing.
+  return forwardedHost.split(",")[0]?.trim() || null;
+}
+
 export function getRpId(req: Request) {
-  const host = req.headers.get("host") || "envault.tech";
+  const host = getForwardedHost(req) || req.headers.get("host") || "envault.tech";
   // Remove port if present for rpID
   return host.split(":")[0];
 }
 
 export function getExpectedOrigin(req: Request) {
-  const host = req.headers.get("host") || "envault.tech";
-  // WebAuthn requires https unless it's localhost
-  const protocol = host.includes("localhost") ? "http" : "https";
+  const host = getForwardedHost(req) || req.headers.get("host") || "envault.tech";
+  const forwardedProto = req.headers.get("x-forwarded-proto");
+  const protocol = forwardedProto || "https";
   return `${protocol}://${host}`;
 }


### PR DESCRIPTION
## Summary
This PR migrates local development and auth flows from ngrok/localhost assumptions to `portless` HTTPS.

## What Changed
- Switched dev startup to `portless` HTTPS domain flow (`envault.localhost`) in npm scripts.
- Replaced ngrok-only dev origin configuration with portless local domain allowlist.
- Updated auth redirect generation to prioritize `NEXT_PUBLIC_APP_URL` for stable OAuth callbacks.
- Updated auth callback redirects to prefer `NEXT_PUBLIC_APP_URL` after session exchange.
- Updated WebAuthn RP ID / expected origin derivation to respect forwarded host/proto behind proxy.
- Enforced HTTPS-only CLI base URL by default (explicit insecure override available for tests).
- Updated docs/examples from `localhost` app URLs to `envault.localhost` and refreshed local setup guidance.
- Cleaned lingering localhost examples/fallbacks in docs and API examples.

## Why
- Remove dependency on ephemeral ngrok domains.
- Keep local callback origins consistent for OAuth and passkeys.
- Avoid random localhost dev ports leaking into auth redirect flows.
- Standardize local development on HTTPS by default.

## Testing
- Manual local verification of login flows via portless HTTPS.
- Lint checks run on touched TypeScript files in active workspace.
- Note: full lint in clean PR worktree requires dependency install in that worktree.

Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>
