### PR TITLE
feat(github): multi-account install flow, audit-log expansion, and integration UX polish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,8 +20,8 @@ UPSTASH_REDIS_REST_TOKEN=your_upstash_redis_rest_token_here
 
 ## Application URLs
 # Optional; used for constructing links, redirecting, and CLI
-NEXT_PUBLIC_APP_URL=https://localhost:3000
-ENVAULT_CLI_URL=https://localhost:3000/api/cli
+NEXT_PUBLIC_APP_URL=https://envault.localhost:1355
+ENVAULT_CLI_URL=https://envault.localhost:1355/api/cli
 
 ## Scheduling
 # Secret used to authenticate incoming cron requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to Envault are documented here.
 
 ---
 
-## 1.4.0 — 2026-03-17
+## 1.4.0 - 2026-03-17
 
 > Authors: Dinanath Dash (DinanathDash), Rajat Patra (RawJat)
 
@@ -34,7 +34,7 @@ All notable changes to Envault are documented here.
 
 ---
 
-## 1.3.0 — 2026-03-14
+## 1.3.0 - 2026-03-14
 
 > Authors: Dinanath Dash (DinanathDash), Rajat Patra (RawJat)
 
@@ -54,7 +54,7 @@ All notable changes to Envault are documented here.
 
 ---
 
-## 1.2.1 — 2026-03-10
+## 1.2.1 - 2026-03-10
 
 > Authors: Dinanath Dash (DinanathDash), Rajat Patra (RawJat)
 
@@ -71,7 +71,7 @@ All notable changes to Envault are documented here.
 
 ---
 
-## 1.2.0 — 2026-03-09
+## 1.2.0 - 2026-03-09
 
 > Authors: Dinanath Dash (DinanathDash), Rajat Patra (RawJat)
 
@@ -93,7 +93,7 @@ All notable changes to Envault are documented here.
 
 ---
 
-## 1.1.0 — 2026-03-03
+## 1.1.0 - 2026-03-03
 
 > Authors: Dinanath Dash (DinanathDash), Rajat Patra (RawJat)
 
@@ -121,7 +121,7 @@ All notable changes to Envault are documented here.
 
 ---
 
-## 1.0.0 — 2026-02-28
+## 1.0.0 - 2026-02-28
 
 > Authors: Dinanath Dash (DinanathDash), Rajat Patra (RawJat)
 
@@ -130,9 +130,9 @@ All notable changes to Envault are documented here.
 - **Non-Blocking CLI Updates:** CLI now checks for updates in the background without blocking command execution. Update notifications appear after the command completes.
 - **GitHub App Integration:** Implemented full GitHub App installation flow for linking repositories to Envault projects, enabling automated access management.
 - **CLI Auto-Refresh Sessions:** Implemented rolling session auto-refresh for the CLI with CI/CD service token guardrails, allowing Envault to be used in automated pipelines without re-authentication.
-- **CLI Workspace Mode:** Enhanced `envault init` with workspace-aware project creation — supports selecting a default environment during setup for streamlined multi-environment workflows.
+- **CLI Workspace Mode:** Enhanced `envault init` with workspace-aware project creation - supports selecting a default environment during setup for streamlined multi-environment workflows.
 - **CLI Environment Management:** Added dedicated CLI commands for managing project environments, enabling environment-scoped secret operations without opening the web UI.
-- **JIT Access:** Introduced a JIT access request workflow — users can request project access which owners approve or deny, with pending requests auto-cleaned on approval.
+- **JIT Access:** Introduced a JIT access request workflow - users can request project access which owners approve or deny, with pending requests auto-cleaned on approval.
 - **System Status Page:** Launched a dedicated `/status` page with real-time health indicators, incident timeline, and admin management view.
 - **Shared Data Validation Schemas:** Centralised Zod schemas for shared API validation across CLI and web application endpoints.
 - **Email Digest Cron Job:** Added a `/api/cron` endpoint for scheduled email digests, secured with Vercel cron authentication.
@@ -145,13 +145,13 @@ All notable changes to Envault are documented here.
 
 ---
 
-## 0.9.0 — 2026-02-22
+## 0.9.0 - 2026-02-22
 
 > Authors: Dinanath Dash (DinanathDash), Rajat Patra (RawJat)
 
 ### Features
 
-- **WebAuthn / Passkeys:** Implemented full WebAuthn (FIDO2) passwordless authentication — users can register biometric or hardware passkeys and log in without a password.
+- **WebAuthn / Passkeys:** Implemented full WebAuthn (FIDO2) passwordless authentication - users can register biometric or hardware passkeys and log in without a password.
 - **HMAC Request Signing:** Introduced HMAC-SHA256 signing for sensitive API requests, with a client-side `HmacProvider` injecting signatures into request headers, enforced by a strict CSP.
 - **Slug-Based Project Routing:** Migrated project URLs from internal IDs to human-readable slugs (`/[handle]/[project-slug]`), matching GitHub-style semantic routing.
 - **User Profiles:** Introduced user profile records (handle, display name, avatar) created automatically on signup, powering the new URL scheme.
@@ -165,7 +165,7 @@ All notable changes to Envault are documented here.
 
 ---
 
-## 0.8.0 — 2026-02-12
+## 0.8.0 - 2026-02-12
 
 > Authors: Dinanath Dash (DinanathDash)
 
@@ -174,7 +174,7 @@ All notable changes to Envault are documented here.
 - **Status Page Incident Timeline:** Refactored the status page incident view into a dedicated `Timeline` component with visual severity indicators and chronological ordering.
 - **Comprehensive System Status:** Launched the foundational system status infrastructure with an admin view for creating and managing incidents.
 - **Page Transitions:** Implemented full-page enter/exit transition animations using Framer Motion, wired to the Next.js App Router's navigation events.
-- **Go CLI:** Published the Envault Go CLI (`cli-go`) — a high-performance binary for managing secrets from the terminal. Distributed via an npm wrapper (`@dinanathdash/envault`) and Homebrew.
+- **Go CLI:** Published the Envault Go CLI (`cli-go`) - a high-performance binary for managing secrets from the terminal. Distributed via an npm wrapper (`@dinanathdash/envault`) and Homebrew.
 - **CLI JIT Offline Cache:** CLI now caches project and secret metadata locally for resilience when the Envault API is temporarily unreachable.
 
 ### Security
@@ -183,7 +183,7 @@ All notable changes to Envault are documented here.
 
 ---
 
-## 0.7.0 — 2026-02-07
+## 0.7.0 - 2026-02-07
 
 > Authors: Dinanath Dash (DinanathDash)
 
@@ -193,11 +193,11 @@ All notable changes to Envault are documented here.
 - **Mermaid Diagram Support:** Added `mermaid` rendering support inside documentation pages for architecture and flow diagrams.
 - **`AnimatedWorkflow` Component:** Built an interactive animated workflow diagram for the landing page, visually communicating the Envault secret sync flow.
 - **Custom 404 Page:** Implemented a branded, animated Not Found page with navigation recovery options.
-- **Middleware — Auth & Routing:** Added global Next.js middleware for session-based authentication gating and static file exclusion rules.
+- **Middleware - Auth & Routing:** Added global Next.js middleware for session-based authentication gating and static file exclusion rules.
 
 ---
 
-## 0.6.0 — 2026-02-04
+## 0.6.0 - 2026-02-04
 
 > Authors: Dinanath Dash (DinanathDash)
 
@@ -212,7 +212,7 @@ All notable changes to Envault are documented here.
 
 ---
 
-## 0.5.0 — 2026-02-03
+## 0.5.0 - 2026-02-03
 
 > Authors: Dinanath Dash (DinanathDash), Rajat Patra (RawJat)
 
@@ -231,20 +231,20 @@ All notable changes to Envault are documented here.
 
 ---
 
-## 0.4.0 — 2026-02-01
+## 0.4.0 - 2026-02-01
 
 > Authors: Dinanath Dash (DinanathDash)
 
 ### Features
 
-- **CLI Device Authentication:** Implemented the OAuth 2.0 Device Authorization flow for CLI login — users authenticate in the browser and the CLI polls for token confirmation.
+- **CLI Device Authentication:** Implemented the OAuth 2.0 Device Authorization flow for CLI login - users authenticate in the browser and the CLI polls for token confirmation.
 - **CLI API Routes:** Added dedicated Next.js API routes for CLI interactions: `/api/cli/projects`, `/api/cli/secrets`, `/api/cli/me`, and `/api/cli/environments`.
 - **Clipboard Support for Login:** CLI login now copies the device code to the clipboard automatically on supported platforms.
 - **`envault deploy` & `envault pull`:** Added CLI commands to push local `.env` files to a project environment and pull secrets to a local file.
 
 ---
 
-## 0.3.0 — 2026-01-25
+## 0.3.0 - 2026-01-25
 
 > Authors: Dinanath Dash (DinanathDash)
 
@@ -259,13 +259,13 @@ All notable changes to Envault are documented here.
 
 ---
 
-## 0.2.0 — 2026-01-06
+## 0.2.0 - 2026-01-06
 
 > Authors: Dinanath Dash (DinanathDash)
 
 ### Features
 
-- **Key Wrapping & Rotation:** Implemented a full hierarchical encryption model — a Master Key encrypts unique per-project Data Keys. Data Keys can be rotated with a background scavenger process that re-encrypts all secrets using chunked processing.
+- **Key Wrapping & Rotation:** Implemented a full hierarchical encryption model - a Master Key encrypts unique per-project Data Keys. Data Keys can be rotated with a background scavenger process that re-encrypts all secrets using chunked processing.
 - **GitHub Authentication:** Added GitHub OAuth as an alternative sign-in provider via Supabase Auth.
 - **Variable Visibility Toggle:** Users can now reveal/mask individual secret values inline within the environment variable table.
 - **Tooltip Component:** Added a reusable `<Tooltip>` component used throughout the variable table and action buttons.
@@ -275,7 +275,7 @@ All notable changes to Envault are documented here.
 
 ---
 
-## 0.1.0 — 2026-01-03
+## 0.1.0 - 2026-01-03
 
 > Authors: Dinanath Dash (DinanathDash)
 
@@ -283,9 +283,9 @@ All notable changes to Envault are documented here.
 
 - **Core Application Scaffold:** Bootstrapped with Next.js 15 App Router, TypeScript, Tailwind CSS, and Shadcn UI component library.
 - **User Authentication:** Full email/password authentication powered by Supabase Auth, including signup, login, and session management via SSR-compatible cookies.
-- **Project Management:** Users can create, view, and delete projects — organisational units for grouping related environment variables.
+- **Project Management:** Users can create, view, and delete projects - organisational units for grouping related environment variables.
 - **Environment Variable Vault:** Core secret storage with AES-256-GCM authenticated encryption. Each secret is encrypted with a project-scoped Data Key before being persisted to the database.
 - **Bulk `.env` Import:** Paste or upload a raw `.env` file and Envault parses, encrypts, and stores all key-value pairs in a single operation.
 - **UI Component Library:** Established the full Shadcn/Radix UI component foundation: `Button`, `Dialog`, `Input`, `Card`, `Badge`, `DropdownMenu`, `Avatar`, and more.
-- **Async Secret Decryption:** Secrets are decrypted on-demand in the browser — plaintext values are never persisted to the client beyond the active session.
+- **Async Secret Decryption:** Secrets are decrypted on-demand in the browser - plaintext values are never persisted to the client beyond the active session.
 - **User Sign-Out:** Secure server-side sign-out with session invalidation and redirect to the login page.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Follow these steps to get the project running locally.
     npm run dev
     ```
 
-    Open [https://envault.localhost](https://envault.localhost) with your browser to see the result.
+    Open [https://envault.localhost:1355](https://envault.localhost:1355) with your browser to see the result.
 
 5.  **Test Email Configuration (Optional)**
 

--- a/RELEASE_STEPS.md
+++ b/RELEASE_STEPS.md
@@ -1,6 +1,7 @@
 # Envault Manual Release Guide
 
 This repo uses a hybrid release flow:
+
 - App release: manual
 - CLI release: automatic (GitHub Actions)
 
@@ -27,12 +28,15 @@ These are independent and should be bumped only when that surface changes.
 Use this when web/app features change.
 
 1. Update changelog manually in [`CHANGELOG.md`](./CHANGELOG.md):
-   - Move `Unreleased` items into a real version heading (example: `## 1.3.0 — 2026-03-10`).
+   - Move `Unreleased` items into a real version heading (example: `## 1.3.0 - 2026-03-10`).
 2. Bump app version in root:
+
 ```bash
 npm version <major|minor|patch> --no-git-tag-version
 ```
+
 3. Review and commit:
+
 ```bash
 git add CHANGELOG.md package.json package-lock.json
 git commit -m "chore(app-release): bump app version to X.Y.Z"

--- a/content/docs/cli/reference.mdx
+++ b/content/docs/cli/reference.mdx
@@ -94,6 +94,12 @@ envault deploy --env preview --file .env.preview
 
 See [Commands](/docs/cli/commands) for full details.
 
+<Callout type="info">
+  If a project has GitHub Integration enabled, `envault pull` can auto-grant
+  Viewer access for repository collaborators (Just-in-Time access) before
+  returning secrets.
+</Callout>
+
 ## Environment-Scoped Local Files
 
 When a command needs a local env file (`pull`, `diff`, `deploy`), Envault resolves file path in this order:

--- a/content/docs/configuration/environment-variables.mdx
+++ b/content/docs/configuration/environment-variables.mdx
@@ -24,6 +24,18 @@ These environment variables are required to run the Envault server (Next.js app)
 | `RESEND_API_KEY` | Resend API key for sending application emails. | `re_123456789...`        |
 | `LOG_LEVEL`      | Logging verbosity.                             | `info`                   |
 
+### GitHub Integration Variables (Optional)
+
+If you enable GitHub integration, add the following:
+
+| Variable | Description | Example |
+| :--- | :--- | :--- |
+| `NEXT_PUBLIC_GITHUB_APP_NAME` | GitHub App slug name | `envault` |
+| `ENVAULT_GITHUB_APP_CLIENT_ID` | GitHub App client ID | `Iv1.xxxxx` |
+| `ENVAULT_GITHUB_APP_CLIENT_SECRET` | GitHub App client secret | `xxxxxx` |
+| `ENVAULT_GITHUB_APP_PRIVATE_KEY` | GitHub App private key (single-line, `\n` escaped) | `"-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"` |
+| `ENVAULT_GITHUB_WEBHOOK_SECRET` | Secret to verify GitHub webhook signatures | `whsec_xxxxx` |
+
 ## Generating Keys
 
 To generate a secure `ENCRYPTION_KEY`, use:

--- a/content/docs/guides/github-integration.mdx
+++ b/content/docs/guides/github-integration.mdx
@@ -12,10 +12,11 @@ The GitHub Integration lets you link an Envault project to a specific GitHub rep
 ## How It Works
 
 1. You install the **Envault GitHub App** on your GitHub account or organization.
-2. You link the app to a specific repository in your Envault project settings.
-3. When a team member runs `envault pull`, Envault checks their GitHub identity against that repository's collaborator list.
-4. If they are a collaborator, they are automatically granted `viewer` access and their secrets are returned.
-5. If they are not a collaborator, the CLI prompts them to submit an access request, which notifies the project owner and includes the requested environment when provided.
+2. Envault first routes you through GitHub's native account picker so you can confirm the correct identity before install.
+3. You link the app to a specific repository in your Envault project settings.
+4. When a team member runs `envault pull`, Envault checks their GitHub identity against that repository's collaborator list.
+5. If they are a collaborator, they are automatically granted `viewer` access and their secrets are returned.
+6. If they are not a collaborator, the CLI prompts them to submit an access request, which notifies the project owner and includes the requested environment when provided.
 
 <Callout type="info">
   JIT access only grants the **Viewer** role. To give a team member Editor or Owner access, invite them manually from the project settings.
@@ -27,16 +28,17 @@ The GitHub Integration lets you link an Envault project to a specific GitHub rep
   <Step>
     ### Install the GitHub App
 
-    Open your Envault project, click the <Settings className="inline w-4 h-4 mx-1" /> **Settings** icon in the project header, and select **<Github className="inline w-4 h-4 mx-1" /> GitHub Integration**. Click **Connect GitHub Repository**.
+    Open your Envault project, click the <Settings className="inline w-4 h-4 mx-1" /> **Settings** icon in the project header, and select **<Github className="inline w-4 h-4 mx-1" /> GitHub Integration**. Click **Connect GitHub Account** (or **Add account**).
 
-    - **First project**: You will be redirected to GitHub to install the Envault GitHub App on your account or organization, then redirected back automatically.
-    - **Additional projects**: If the app is already installed, the repository picker appears immediately - no GitHub redirect needed.
+    - You are redirected to GitHub OAuth first, where GitHub shows "Continue as ..." or "Use a different account".
+    - After identity selection, GitHub redirects back and Envault sends you to the App installation screen under that selected GitHub account.
+    - Once installation completes, Envault returns you to the project and prompts for repository selection.
   </Step>
 
   <Step>
     ### Select a Repository
 
-    The dialog shows a list of repositories the app has access to. Select the one that corresponds to this project.
+    The dialog shows repositories available to the selected GitHub account. Select the one that corresponds to this project.
 
     <Callout type="info">
       Each repository can only be linked to one project at a time. If a repository is already linked elsewhere, you will need to unlink it first.
@@ -46,7 +48,7 @@ The GitHub Integration lets you link an Envault project to a specific GitHub rep
   <Step>
     ### Done
 
-    The dialog shows **Successfully Linked** with the repository name. From this point, any collaborator on that repository who runs `envault pull` will automatically receive access.
+    The dialog shows **Linked Repository** with the repository name. Once linked, the picker/search list is hidden to prevent accidental relinking. From this point, any collaborator on that repository who runs `envault pull` will automatically receive access.
   </Step>
 </Steps>
 
@@ -55,6 +57,15 @@ The GitHub Integration lets you link an Envault project to a specific GitHub rep
 Click <Unlink className="inline w-4 h-4 mx-1" /> **Unlink** in the GitHub Integration dialog. This clears the linked repository but keeps the GitHub App installed - you can immediately select a different repository without going through GitHub again.
 
 To fully remove the integration, uninstall the Envault GitHub App from [github.com/settings/installations](https://github.com/settings/installations). Envault will automatically clear the linked data via webhook.
+
+## Audit Log Events
+
+GitHub integration actions are written to project audit logs with dedicated event names:
+
+- `github.account_connected`: a GitHub App installation was completed for the project flow.
+- `github.account_disconnected`: the GitHub App installation was removed (webhook-driven).
+- `github.repo_linked`: a repository was linked from the integration dialog.
+- `github.repo_unlinked`: a repository was unlinked manually or via app uninstall webhook.
 
 ## Access Request Flow
 
@@ -91,6 +102,7 @@ If you are self-hosting Envault, you need to create your own GitHub App and conf
 
 In your GitHub App settings, set:
 
+- **Callback URL**: `https://your-domain.com/api/github/callback`
 - **Setup URL**: `https://your-domain.com/api/github/callback`
 - **Webhook URL**: `https://your-domain.com/api/github/webhook`
 - **Webhook secret**: same value as `ENVAULT_GITHUB_WEBHOOK_SECRET`

--- a/src/app/(marketing)/changelog/page.tsx
+++ b/src/app/(marketing)/changelog/page.tsx
@@ -8,7 +8,7 @@ import {
 export const metadata: Metadata = {
   title: "Changelog",
   description:
-    "Every notable release to Envault — new features, security patches, and CLI updates, documented in order.",
+    "Every notable release to Envault - new features, security patches, and CLI updates, documented in order.",
   alternates: {
     canonical: "/changelog",
   },

--- a/src/app/[handle]/[slug]/page.tsx
+++ b/src/app/[handle]/[slug]/page.tsx
@@ -321,7 +321,6 @@ export default async function SharedProjectPage({
     name: project.name,
     slug: project.slug,
     user_id: project.user_id,
-    github_installation_id: project.github_installation_id ?? null,
     github_repo_full_name: project.github_repo_full_name ?? null,
     ui_mode: project.ui_mode || "simple",
     default_environment_slug:

--- a/src/app/api/audit/github/route.ts
+++ b/src/app/api/audit/github/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { logAuditEvent } from "@/lib/system/audit-logger";
+
+const ALLOWED_GITHUB_ACTIONS = [
+  "github.repo_linked",
+  "github.repo_unlinked",
+] as const;
+
+type AllowedAction = (typeof ALLOWED_GITHUB_ACTIONS)[number];
+
+export async function POST(request: Request) {
+  // Authenticate the caller
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: { action?: string; projectId?: string; metadata?: Record<string, unknown> };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { action, projectId, metadata } = body;
+
+  if (!action || !ALLOWED_GITHUB_ACTIONS.includes(action as AllowedAction)) {
+    return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+  }
+
+  if (!projectId) {
+    return NextResponse.json({ error: "Missing projectId" }, { status: 400 });
+  }
+
+  // Verify the user has access to this project before logging
+  const { data: project } = await supabase
+    .from("projects")
+    .select("id, user_id")
+    .eq("id", projectId)
+    .single();
+
+  if (!project) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  await logAuditEvent({
+    projectId,
+    actorId: user.id,
+    actorType: "user",
+    action: action as AllowedAction,
+    metadata: metadata ?? {},
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/cli/projects/[projectId]/secrets/route.ts
+++ b/src/app/api/cli/projects/[projectId]/secrets/route.ts
@@ -97,7 +97,7 @@ export async function GET(
     // Check if user has full project access (owner or member)
     const { data: project } = await supabase
       .from("projects")
-      .select("user_id, github_installation_id, github_repo_full_name")
+      .select("user_id, github_repo_full_name")
       .eq("id", projectId)
       .single();
 
@@ -171,8 +171,19 @@ export async function GET(
         // ── JIT GitHub Collaborator Check ──────────────────────────────────
         // If the project is linked to a GitHub repo, check if the requesting
         // user is a collaborator before falling back to a manual request.
-        const installationId = project?.github_installation_id;
         const repoFullName = project?.github_repo_full_name;
+
+        // Resolve the installation_id from github_installations (owned by project owner)
+        let installationId: number | null = null;
+        if (repoFullName && project?.user_id) {
+          const { data: installRow } = await supabase
+            .from("github_installations")
+            .select("installation_id")
+            .eq("user_id", project.user_id)
+            .limit(1)
+            .single();
+          installationId = installRow?.installation_id ?? null;
+        }
 
         if (installationId && repoFullName) {
           const githubUsername = await getGitHubUsername(supabase, userId);

--- a/src/app/api/github/add-account/route.ts
+++ b/src/app/api/github/add-account/route.ts
@@ -1,0 +1,66 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+function baseUrl(): string {
+  return process.env.NEXT_PUBLIC_APP_URL || "https://envault.localhost:1355";
+}
+
+/**
+ * Server-side route that initiates a GitHub OAuth authorization flow.
+ * Because it goes through /login/oauth/authorize (not the App install URL),
+ * GitHub shows its native account picker — "Continue as X / Use a different account".
+ * After the user picks an account, GitHub redirects to /api/github/callback
+ * with `code` + `state`. The callback detects the OAuth-only flow (no installation_id)
+ * and sends the user to the GitHub App installation page for the now-active session.
+ *
+ * This route requires authentication so it can verify the project before
+ * initiating the OAuth flow.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const projectId = searchParams.get("project_id") ?? "";
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.redirect(new URL("/login", baseUrl()));
+  }
+
+  if (!projectId) {
+    return NextResponse.redirect(new URL("/dashboard", baseUrl()));
+  }
+
+  const clientId = process.env.ENVAULT_GITHUB_APP_CLIENT_ID;
+  if (!clientId) {
+    return NextResponse.json(
+      { error: "GitHub App not configured" },
+      { status: 500 },
+    );
+  }
+
+  const oauthUrl = new URL("https://github.com/login/oauth/authorize");
+  oauthUrl.searchParams.set("client_id", clientId);
+  oauthUrl.searchParams.set(
+    "redirect_uri",
+    `${baseUrl()}/api/github/callback`,
+  );
+  // state encodes projectId so the callback knows which project to update
+  oauthUrl.searchParams.set("state", projectId);
+  // No scopes needed - we only use this to trigger the account picker.
+  // The actual installation gets its own permissions through the App install flow.
+  oauthUrl.searchParams.set("scope", "");
+
+  const response = NextResponse.redirect(oauthUrl);
+  // Also persist the project id in a cookie as a fallback if state is lost
+  response.cookies.set("github_oauth_project_id", projectId, {
+    maxAge: 300,
+    path: "/",
+    sameSite: "lax",
+    secure: !process.env.NODE_ENV || process.env.NODE_ENV === "production",
+  });
+
+  return response;
+}

--- a/src/app/api/github/callback/route.ts
+++ b/src/app/api/github/callback/route.ts
@@ -1,17 +1,77 @@
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { generateGitHubAppJWT } from "@/lib/auth/github";
 import { type NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
-// Use NEXT_PUBLIC_APP_URL so redirects point to the correct domain (ngrok in dev, production domain in prod)
-// rather than the internal localhost:3000 that Next.js sees behind the tunnel.
 function baseUrl(): string {
-  return process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+  return process.env.NEXT_PUBLIC_APP_URL || "https://envault.localhost:1355";
+}
+
+/**
+ * Fetches the installation account info (login + type) from the GitHub App API.
+ * Uses the App JWT so no additional permissions are required.
+ */
+async function getInstallationAccount(
+  installationId: string,
+): Promise<{ account_login: string; account_type: string } | null> {
+  try {
+    const appJwt = generateGitHubAppJWT();
+    const res = await fetch(
+      `https://api.github.com/app/installations/${installationId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${appJwt}`,
+          Accept: "application/vnd.github.v3+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+    );
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      account?: { login?: string; type?: string };
+    };
+    return {
+      account_login: data.account?.login ?? "",
+      account_type: data.account?.type ?? "User",
+    };
+  } catch {
+    return null;
+  }
 }
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const installationId = searchParams.get("installation_id");
+  const oauthCode = searchParams.get("code");
+  const oauthState = searchParams.get("state");
+
+  // OAuth account-picker flow: user came from /api/github/add-account, picked
+  // an account in GitHub's native picker, and was redirected here with `code`
+  // but no `installation_id`. We use this branch purely to bounce them to the
+  // App installation page — NOW under the GitHub session they just chose.
+  if (!installationId && oauthCode) {
+    const cookieStore = await cookies();
+    const projectFromCookie = cookieStore.get("github_oauth_project_id")?.value;
+    const projectId = oauthState || projectFromCookie || "";
+
+    const appName = process.env.NEXT_PUBLIC_GITHUB_APP_NAME || "envault";
+    const installUrl = new URL(
+      `https://github.com/apps/${appName}/installations/new`,
+    );
+
+    // Pass the project id through a fresh cookie so the installation
+    // callback (this same route, with installation_id) can look it up.
+    const response = NextResponse.redirect(installUrl);
+    if (projectId) {
+      response.cookies.set("github_oauth_project_id", projectId, {
+        maxAge: 300,
+        path: "/",
+        sameSite: "lax",
+      });
+    }
+    return response;
+  }
 
   if (!installationId) {
     return NextResponse.json(
@@ -20,8 +80,6 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  // GitHub Setup URL does NOT forward the `state` param -
-  // we read the projectId from the cookie we set before redirecting to GitHub.
   const cookieStore = await cookies();
   const projectId = cookieStore.get("github_oauth_project_id")?.value;
 
@@ -30,20 +88,23 @@ export async function GET(request: NextRequest) {
       new URL("/dashboard?error=missing_project_state", baseUrl()),
     );
   }
+
   const supabase = await createClient();
 
-  // 1. Verify the user is logged in
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
   if (!user) {
     return NextResponse.redirect(
-      new URL(`/login?next=/api/github/callback?installation_id=${installationId}`, baseUrl()),
+      new URL(
+        `/login?next=/api/github/callback?installation_id=${installationId}`,
+        baseUrl(),
+      ),
     );
   }
 
-  // 2. Verify permission: User must be Owner or Editor of the project
+  // Verify permission: User must be Owner or Editor of the project
   const { data: projectMember } = await supabase
     .from("project_members")
     .select("role")
@@ -70,22 +131,49 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  // 3. Update the project with the installation_id
-  // Use admin client to bypass RLS - we've already verified ownership above.
   const adminSupabase = createAdminClient();
 
-  // Fetch the slug first so we can redirect back to the correct project URL
+  // Fetch account info from GitHub App API (login + type)
+  const accountInfo = await getInstallationAccount(installationId);
+
+  // Upsert into github_installations so this user can select this installation
+  // from any project. On conflict (same user + installation), update account info.
+  await adminSupabase.from("github_installations").upsert(
+    {
+      user_id: user.id,
+      installation_id: parseInt(installationId),
+      account_login: accountInfo?.account_login ?? null,
+      account_type: accountInfo?.account_type ?? null,
+    },
+    { onConflict: "user_id,installation_id" },
+  );
+
+  // Audit: record that a GitHub account was connected for this project
+  const { logAuditEvent } = await import("@/lib/system/audit-logger");
+  logAuditEvent({
+    projectId,
+    actorId: user.id,
+    actorType: "user",
+    action: "github.account_connected",
+    targetResourceId: installationId,
+    metadata: {
+      installation_id: parseInt(installationId),
+      account_login: accountInfo?.account_login ?? null,
+      account_type: accountInfo?.account_type ?? null,
+    },
+  }).catch((e) => console.error("[Audit] github.account_connected failed:", e));
+
+  // Fetch the project slug so we can redirect back to the correct project URL
   const { data: projectData } = await adminSupabase
     .from("projects")
     .select("slug")
     .eq("id", projectId)
     .single();
 
+  // Clear the linked repo so the UI prompts the user to pick one
   const { error } = await adminSupabase
     .from("projects")
     .update({
-      github_installation_id: parseInt(installationId),
-      // Clear the repo name: UI will prompt user to select a repo next
       github_repo_full_name: null,
     })
     .eq("id", projectId);
@@ -97,12 +185,13 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  // Redirect back to the project page - the UI detects ?success=github_linked
-  // and opens the GitHub integration dialog in repo-selection state.
   const projectSlug = projectData?.slug || projectId;
   const redirectResponse = NextResponse.redirect(
     new URL(`/project/${projectSlug}?success=github_linked`, baseUrl()),
   );
-  redirectResponse.cookies.set("github_oauth_project_id", "", { maxAge: 0, path: "/" });
+  redirectResponse.cookies.set("github_oauth_project_id", "", {
+    maxAge: 0,
+    path: "/",
+  });
   return redirectResponse;
 }

--- a/src/app/api/github/repositories/route.ts
+++ b/src/app/api/github/repositories/route.ts
@@ -1,6 +1,17 @@
 import { NextResponse } from "next/server";
 import { generateGitHubAppJWT } from "@/lib/auth/github";
 
+interface GitHubRepo {
+  id: number;
+  full_name: string;
+  private: boolean;
+  fork: boolean;
+  pushed_at: string;
+  owner: {
+    login: string;
+  };
+}
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const installationId = searchParams.get("installation_id");
@@ -13,10 +24,8 @@ export async function GET(request: Request) {
   }
 
   try {
-    // 1. Generate the App JWT
     const appJwt = generateGitHubAppJWT();
 
-    // 2. Get an Installation Access Token for this specific installation
     const tokenResponse = await fetch(
       `https://api.github.com/app/installations/${installationId}/access_tokens`,
       {
@@ -24,12 +33,12 @@ export async function GET(request: Request) {
         headers: {
           Authorization: `Bearer ${appJwt}`,
           Accept: "application/vnd.github.v3+json",
+          "X-GitHub-Api-Version": "2022-11-28",
         },
       },
     );
 
     if (!tokenResponse.ok) {
-      await tokenResponse.text();
       return NextResponse.json(
         { error: "Failed to authenticate with GitHub" },
         { status: 500 },
@@ -38,47 +47,55 @@ export async function GET(request: Request) {
 
     const { token } = (await tokenResponse.json()) as { token: string };
 
-    // 3. Fetch the repositories accessible to this installation
-    const reposResponse = await fetch(
-      "https://api.github.com/installation/repositories",
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/vnd.github.v3+json",
-        },
-      },
-    );
+    // Paginate through all repos for this installation
+    const allRepos: GitHubRepo[] = [];
+    let page = 1;
 
-    if (!reposResponse.ok) {
-      await reposResponse.text();
-      return NextResponse.json(
-        { error: "Failed to fetch repositories" },
-        { status: 500 },
+    while (true) {
+      const reposResponse = await fetch(
+        `https://api.github.com/installation/repositories?per_page=100&page=${page}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github.v3+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+        },
       );
+
+      if (!reposResponse.ok) {
+        return NextResponse.json(
+          { error: "Failed to fetch repositories" },
+          { status: 500 },
+        );
+      }
+
+      const data = (await reposResponse.json()) as {
+        repositories?: GitHubRepo[];
+      };
+
+      const repos = data.repositories ?? [];
+      allRepos.push(...repos);
+
+      if (repos.length < 100) break;
+      page++;
     }
 
-    const reposData = (await reposResponse.json()) as {
-      repositories?: Array<{
-        id: number;
-        full_name: string;
-        pushed_at: string;
-      }>;
-    };
-
     // Sort by last push date descending (most recently active first)
-    const sorted = (reposData.repositories ?? []).sort(
-      (a: { pushed_at: string }, b: { pushed_at: string }) =>
+    const sorted = [...allRepos].sort(
+      (a, b) =>
         new Date(b.pushed_at).getTime() - new Date(a.pushed_at).getTime(),
     );
 
     return NextResponse.json({
-      repositories: sorted.map(
-        (r: { id: number; full_name: string; pushed_at: string }) => ({
-          id: r.id,
-          full_name: r.full_name,
-          pushed_at: r.pushed_at,
-        }),
-      ),
+      repositories: sorted.map((r) => ({
+        id: r.id,
+        full_name: r.full_name,
+        private: r.private,
+        fork: r.fork,
+        pushed_at: r.pushed_at,
+        owner_login: r.owner.login,
+      })),
     });
   } catch {
     return NextResponse.json(

--- a/src/app/api/github/repositories/search/route.ts
+++ b/src/app/api/github/repositories/search/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from "next/server";
+import { generateGitHubAppJWT } from "@/lib/auth/github";
+
+interface GitHubRepo {
+  id: number;
+  full_name: string;
+  private: boolean;
+  fork: boolean;
+  pushed_at: string;
+  owner: {
+    login: string;
+  };
+}
+
+async function fetchAllRepos(installationId: string): Promise<GitHubRepo[]> {
+  const appJwt = generateGitHubAppJWT();
+
+  const tokenResponse = await fetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${appJwt}`,
+        Accept: "application/vnd.github.v3+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+
+  if (!tokenResponse.ok) {
+    throw new Error("Failed to authenticate with GitHub installation");
+  }
+
+  const { token } = (await tokenResponse.json()) as { token: string };
+
+  const allRepos: GitHubRepo[] = [];
+  let page = 1;
+
+  while (true) {
+    const reposResponse = await fetch(
+      `https://api.github.com/installation/repositories?per_page=100&page=${page}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github.v3+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+    );
+
+    if (!reposResponse.ok) {
+      throw new Error("Failed to fetch repositories from GitHub");
+    }
+
+    const data = (await reposResponse.json()) as {
+      repositories?: GitHubRepo[];
+      total_count?: number;
+    };
+
+    const repos = data.repositories ?? [];
+    allRepos.push(...repos);
+
+    if (repos.length < 100) break;
+    page++;
+  }
+
+  return allRepos;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const installationId = searchParams.get("installation_id");
+  const query = searchParams.get("q")?.trim().toLowerCase() ?? "";
+
+  if (!installationId) {
+    return NextResponse.json(
+      { error: "Missing installation_id" },
+      { status: 400 },
+    );
+  }
+
+  if (!query) {
+    return NextResponse.json({ repositories: [] });
+  }
+
+  try {
+    const allRepos = await fetchAllRepos(installationId);
+
+    const matched = allRepos
+      .filter((r) => r.full_name.toLowerCase().includes(query))
+      .sort(
+        (a, b) =>
+          new Date(b.pushed_at).getTime() - new Date(a.pushed_at).getTime(),
+      );
+
+    return NextResponse.json({
+      repositories: matched.map((r) => ({
+        id: r.id,
+        full_name: r.full_name,
+        private: r.private,
+        fork: r.fork,
+        pushed_at: r.pushed_at,
+        owner_login: r.owner.login,
+      })),
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -2,8 +2,13 @@ import { createHmac, timingSafeEqual } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 
-function verifySignature(secret: string, body: string, signature: string): boolean {
-  const expectedSig = "sha256=" + createHmac("sha256", secret).update(body).digest("hex");
+function verifySignature(
+  secret: string,
+  body: string,
+  signature: string,
+): boolean {
+  const expectedSig =
+    "sha256=" + createHmac("sha256", secret).update(body).digest("hex");
   try {
     return timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSig));
   } catch {
@@ -14,7 +19,10 @@ function verifySignature(secret: string, body: string, signature: string): boole
 export async function POST(req: NextRequest) {
   const webhookSecret = process.env.ENVAULT_GITHUB_WEBHOOK_SECRET;
   if (!webhookSecret) {
-    return NextResponse.json({ error: "Webhook secret not configured" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Webhook secret not configured" },
+      { status: 500 },
+    );
   }
 
   const signature = req.headers.get("x-hub-signature-256") ?? "";
@@ -27,21 +35,85 @@ export async function POST(req: NextRequest) {
   const event = req.headers.get("x-github-event");
   const payload = JSON.parse(body);
 
-  // GitHub App uninstalled - clear both fields for every project linked to this installation
+  // GitHub App uninstalled - clean up both the user-level installation record
+  // and any project repo links that were using this installation.
   if (event === "installation" && payload.action === "deleted") {
     const installationId: number = payload.installation?.id;
     if (installationId) {
       const admin = createAdminClient();
+
+      // Find who owns this installation before deleting
+      const { data: instRow } = await admin
+        .from("github_installations")
+        .select("user_id, account_login")
+        .eq("installation_id", installationId)
+        .single();
+
+      // Remove the user-level installation record
       await admin
-        .from("projects")
-        .update({ github_installation_id: null, github_repo_full_name: null })
-        .eq("github_installation_id", installationId);
+        .from("github_installations")
+        .delete()
+        .eq("installation_id", installationId);
+
+      // Clear the linked repo name from projects that referenced repos from this installation.
+      const repos: Array<{ full_name: string }> =
+        payload.installation?.repositories ?? [];
+
+      let affectedProjects: Array<{
+        id: string;
+        github_repo_full_name: string;
+      }> = [];
+      if (repos.length > 0) {
+        const repoNames = repos.map((r) => r.full_name);
+        const { data: affected } = await admin
+          .from("projects")
+          .select("id, github_repo_full_name")
+          .in("github_repo_full_name", repoNames);
+        affectedProjects = (affected ?? []) as typeof affectedProjects;
+
+        await admin
+          .from("projects")
+          .update({ github_repo_full_name: null })
+          .in("github_repo_full_name", repoNames);
+      }
+
+      // Audit: log account disconnected + individual repo unlinks
+      if (instRow?.user_id) {
+        const { logAuditEvent } = await import("@/lib/system/audit-logger");
+        const actorId = instRow.user_id;
+
+        // One event per affected project for repo_unlinked
+        for (const proj of affectedProjects) {
+          logAuditEvent({
+            projectId: proj.id,
+            actorId,
+            actorType: "user",
+            action: "github.repo_unlinked",
+            metadata: {
+              repo_full_name: proj.github_repo_full_name,
+              reason: "github_app_uninstalled",
+              installation_id: installationId,
+            },
+          }).catch(() => {});
+        }
+
+        // Account disconnected - use first affected project or skip if none
+        const anchorProjectId = affectedProjects[0]?.id;
+        if (anchorProjectId) {
+          logAuditEvent({
+            projectId: anchorProjectId,
+            actorId,
+            actorType: "user",
+            action: "github.account_disconnected",
+            metadata: {
+              installation_id: installationId,
+              account_login: instRow.account_login ?? null,
+            },
+          }).catch(() => {});
+        }
+      }
     }
   }
-
-  // GitHub App suspended (e.g. billing issue) - keep installation ID so reconnect is easy,
-  // but the secrets route will fail the collaborator check anyway since the token will be invalid.
-  // Nothing to do here unless you want to surface a warning in the UI.
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/project/[projectId]/audit-logs/route.ts
+++ b/src/app/api/project/[projectId]/audit-logs/route.ts
@@ -18,6 +18,10 @@ const ALLOWED_AUDIT_ACTIONS = new Set([
   "environment.access_updated",
   "environment.access_granted",
   "environment.access_revoked",
+  "github.account_connected",
+  "github.account_disconnected",
+  "github.repo_linked",
+  "github.repo_unlinked",
 ]);
 
 type EnvAccessState = "none" | "some" | "all" | "unknown";

--- a/src/app/project/[slug]/page.tsx
+++ b/src/app/project/[slug]/page.tsx
@@ -318,7 +318,6 @@ export default async function ProjectPage({ params, searchParams }: PageProps) {
     name: project.name,
     slug: project.slug,
     user_id: project.user_id,
-    github_installation_id: project.github_installation_id ?? null,
     github_repo_full_name: project.github_repo_full_name ?? null,
     ui_mode: project.ui_mode || "simple",
     default_environment_slug:

--- a/src/components/changelog/ChangelogTimeline.tsx
+++ b/src/components/changelog/ChangelogTimeline.tsx
@@ -441,7 +441,7 @@ export function ChangelogTimeline({ entries }: TimelineProps) {
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
-      {/* Mobile version nav — BEFORE pt-24 so it's at y≈0 and immediately sticky at top-16 (flush under navbar) */}
+      {/* Mobile version nav - BEFORE pt-24 so it's at y≈0 and immediately sticky at top-16 (flush under navbar) */}
       <div className="lg:hidden sticky top-16 z-40 bg-background/95 backdrop-blur border-t border-b border-border/50 relative">
         <MobileVersionNav
           entries={entries}
@@ -455,7 +455,10 @@ export function ChangelogTimeline({ entries }: TimelineProps) {
         <RegMark position="top-right" />
 
         {/* Breadcrumb */}
-        <FadeIn delay={0.1} className="container max-w-7xl px-4 md:px-6 py-4 border-b border-border/50">
+        <FadeIn
+          delay={0.1}
+          className="container max-w-7xl px-4 md:px-6 py-4 border-b border-border/50"
+        >
           <div className="flex items-center gap-2 text-sm font-mono text-muted-foreground">
             <Link href="/" className="hover:text-foreground transition-colors">
               Home
@@ -472,7 +475,7 @@ export function ChangelogTimeline({ entries }: TimelineProps) {
 
             {/* Left column */}
             <SlideUp delay={0.2} yOffset={20}>
-              {/* Title block — matches LegalLayout */}
+              {/* Title block - matches LegalLayout */}
               <div className="mb-6 pb-6 md:mb-8 md:pb-8 border-b border-border/50">
                 <h1 className="text-4xl md:text-5xl font-serif font-bold tracking-tight mb-4">
                   Changelog
@@ -485,7 +488,7 @@ export function ChangelogTimeline({ entries }: TimelineProps) {
 
               {/* Timeline */}
               <div ref={containerRef} className="relative">
-                {/* Circuit SVG — desktop only */}
+                {/* Circuit SVG - desktop only */}
                 <svg
                   className="hidden md:block absolute top-0 pointer-events-none select-none overflow-visible"
                   style={{ left: "7rem" }}

--- a/src/components/dashboard/views/audit-logs-view.tsx
+++ b/src/components/dashboard/views/audit-logs-view.tsx
@@ -18,6 +18,7 @@ import {
   ChevronDown,
   ChevronRight,
   Eye,
+  Github,
   KeyRound,
   RefreshCw,
   ShieldCheck,
@@ -75,6 +76,11 @@ interface AuditLogMetadata {
   beneficiary_user_id?: string;
   beneficiary_name?: string;
   beneficiary_email?: string;
+  repo_full_name?: string;
+  reason?: string;
+  installation_id?: number;
+  account_login?: string;
+  account_type?: string;
 }
 
 interface AuditLog {
@@ -120,6 +126,13 @@ const ACTION_OPTIONS = [
   { value: "environment.access_updated", label: "Environment Access Updated" },
   { value: "environment.access_granted", label: "Environment Access Granted" },
   { value: "environment.access_revoked", label: "Environment Access Revoked" },
+  { value: "github.account_connected", label: "GitHub Account Connected" },
+  {
+    value: "github.account_disconnected",
+    label: "GitHub Account Disconnected",
+  },
+  { value: "github.repo_linked", label: "GitHub Repo Linked" },
+  { value: "github.repo_unlinked", label: "GitHub Repo Unlinked" },
 ];
 
 function formatDiffValue(value: unknown): string {
@@ -302,6 +315,7 @@ function getActionIcon(action: string) {
     return <ShieldCheck className="h-3.5 w-3.5" />;
   if (action === "environment.access_revoked")
     return <ShieldOff className="h-3.5 w-3.5" />;
+  if (action.startsWith("github.")) return <Github className="h-3.5 w-3.5" />;
   return <AlertCircle className="h-3.5 w-3.5" />;
 }
 
@@ -399,6 +413,15 @@ function getActionBadgeClass(action: string): string {
     return "border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
   }
   if (action === "transfer.rejected") {
+    return "border-rose-500/25 bg-rose-500/10 text-rose-700 dark:text-rose-300";
+  }
+  if (action === "github.account_connected" || action === "github.repo_linked") {
+    return "border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+  }
+  if (
+    action === "github.account_disconnected" ||
+    action === "github.repo_unlinked"
+  ) {
     return "border-rose-500/25 bg-rose-500/10 text-rose-700 dark:text-rose-300";
   }
 
@@ -597,6 +620,38 @@ function getNonDiffContextSummary(
 
   if (action === "member.invited") {
     return "Member invited";
+  }
+
+  if (action === "github.repo_linked") {
+    if (metadata?.repo_full_name) {
+      return `Linked repository ${metadata.repo_full_name}`;
+    }
+    return "Repository linked";
+  }
+
+  if (action === "github.repo_unlinked") {
+    const repo = metadata?.repo_full_name
+      ? `Unlinked repository ${metadata.repo_full_name}`
+      : "Repository unlinked";
+    const reason =
+      metadata?.reason === "manual"
+        ? "manual unlink"
+        : metadata?.reason === "github_app_uninstalled"
+          ? "GitHub App uninstalled"
+          : "";
+    return reason ? `${repo} (${reason})` : repo;
+  }
+
+  if (action === "github.account_connected") {
+    const account = firstNonEmpty(metadata?.account_login);
+    if (account) return `Connected GitHub account @${account}`;
+    return "GitHub account connected";
+  }
+
+  if (action === "github.account_disconnected") {
+    const account = firstNonEmpty(metadata?.account_login);
+    if (account) return `Disconnected GitHub account @${account}`;
+    return "GitHub account disconnected";
   }
 
   return null;
@@ -887,7 +942,7 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
                   log.metadata,
                   keyName,
                 ) ||
-                (changeEntries.length === 0
+                (changeEntries.length > 0
                   ? getDetailSummary(changeEntries, keyName)
                   : null);
               const shouldShowAffectedUser =
@@ -1050,7 +1105,7 @@ export function AuditLogsView({ projectId }: AuditLogsViewProps) {
           const actionText = getActionLabel(effectiveAction);
           const detailsSummary =
             getNonDiffContextSummary(effectiveAction, log.metadata, keyName) ||
-            (changeEntries.length === 0
+            (changeEntries.length > 0
               ? getDetailSummary(changeEntries, keyName)
               : null);
           const shouldShowAffectedUser =

--- a/src/components/dialogs/github-integration-dialog.tsx
+++ b/src/components/dialogs/github-integration-dialog.tsx
@@ -1,17 +1,25 @@
 "use client";
 
 import * as React from "react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
-  Loader2,
   Github,
   CheckCircle2,
   AlertCircle,
   Link as LinkIcon,
   Unlink,
+  Lock,
+  GitFork,
+  Users,
+  Search,
+  Plus,
+  X,
+  ExternalLink,
+  Building2,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Dialog,
   DialogContent,
@@ -21,6 +29,12 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Project } from "@/lib/stores/store";
 import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
@@ -38,11 +52,56 @@ function formatRelativeTime(dateStr: string): string {
   return `${Math.floor(months / 12)}y ago`;
 }
 
+interface GitHubInstallation {
+  id: number;
+  installation_id: number;
+  account_login: string | null;
+  account_type: string | null;
+  created_at: string;
+}
+
+interface Repo {
+  id: number;
+  full_name: string;
+  private: boolean;
+  fork: boolean;
+  pushed_at?: string;
+  owner_login?: string;
+}
+
 interface GitHubIntegrationDialogProps {
   project: Project;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
+
+function RepoSkeletons() {
+  return (
+    <div className="divide-y">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="flex items-center justify-between gap-3 p-3">
+          <div className="flex flex-col gap-1.5 min-w-0 flex-1">
+            <Skeleton className="h-3.5 w-44" />
+            <Skeleton className="h-3 w-24" />
+          </div>
+          <Skeleton className="h-8 w-16 rounded-md shrink-0" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function AccountSkeletons() {
+  return (
+    <div className="flex gap-2">
+      <Skeleton className="h-8 w-28 rounded-full" />
+      <Skeleton className="h-8 w-24 rounded-full" />
+    </div>
+  );
+}
+
+// Pre-flight sheet removed because we now use GitHub's native OAuth account picker
+// through the /api/github/add-account route.
 
 export function GitHubIntegrationDialog({
   project,
@@ -51,125 +110,135 @@ export function GitHubIntegrationDialog({
 }: GitHubIntegrationDialogProps) {
   const router = useRouter();
   const supabase = createClient();
-  const [isLoading, setIsLoading] = useState(false);
-  const [repos, setRepos] = useState<
-    Array<{ id: number; full_name: string; pushed_at?: string }>
-  >([]);
+
+  const [isLinking, setIsLinking] = useState(false);
+  const [linkingRepoFullName, setLinkingRepoFullName] = useState<string | null>(
+    null,
+  );
   const [isFetchingRepos, setIsFetchingRepos] = useState(false);
-  // Keep a live copy of the project so we can refresh it client-side after
-  // the GitHub callback without depending on the server component re-rendering.
+  const [isFetchingInstallations, setIsFetchingInstallations] = useState(false);
+
+  const [installations, setInstallations] = useState<GitHubInstallation[]>([]);
+  const [selectedInstallationId, setSelectedInstallationId] = useState<
+    number | null
+  >(null);
+
+  const [repos, setRepos] = useState<Repo[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<Repo[] | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+
   const [liveProject, setLiveProject] = useState<Project>(project);
-  // Always sync if the parent passes a newer version (e.g. after router.refresh)
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
     setLiveProject(project);
   }, [project]);
 
-  // When the dialog opens, re-fetch the project row so we always have the
-  // latest github_installation_id / github_repo_full_name from the DB.
+  const fetchInstallations = useCallback(async () => {
+    setIsFetchingInstallations(true);
+    try {
+      const { data, error } = await supabase
+        .from("github_installations")
+        .select("*")
+        .order("created_at", { ascending: true });
+
+      if (error) throw error;
+
+      const rows = (data ?? []) as GitHubInstallation[];
+      setInstallations(rows);
+
+      if (rows.length > 0 && selectedInstallationId === null) {
+        setSelectedInstallationId(rows[0].installation_id);
+      }
+    } catch {
+      toast.error("Failed to load GitHub accounts");
+    } finally {
+      setIsFetchingInstallations(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   useEffect(() => {
     if (!open) return;
+
     supabase
       .from("projects")
       .select("*")
       .eq("id", project.id)
       .single()
       .then(({ data, error }) => {
-        if (error) return;
-        setLiveProject(data as Project);
+        if (!error && data) setLiveProject(data as Project);
       });
+
+    fetchInstallations();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  const isLinked = !!liveProject.github_installation_id;
-  const hasSelectedRepo = !!liveProject.github_repo_full_name;
-  const needsRepoSelection = isLinked && !hasSelectedRepo;
-
-  // Fetch repos if we have an installation but no selected repo
-  useEffect(() => {
-    if (open && needsRepoSelection && liveProject.github_installation_id) {
-      fetchRepositories(liveProject.github_installation_id);
-    }
-  }, [open, needsRepoSelection, liveProject.github_installation_id]);
-
-  const fetchRepositories = async (installationId: number) => {
+  const fetchRepositories = useCallback(async (installationId: number) => {
     setIsFetchingRepos(true);
+    setRepos([]);
+    setSearchQuery("");
+    setSearchResults(null);
     try {
       const res = await fetch(
         `/api/github/repositories?installation_id=${installationId}`,
       );
-      if (!res.ok) {
-        const body = await res.text();
-        throw new Error(`Failed to fetch repositories: ${body}`);
-      }
-      const data = (await res.json()) as {
-        repositories?: Array<{
-          id: number;
-          full_name: string;
-          pushed_at?: string;
-        }>;
-      };
-      setRepos(
-        (data.repositories || []) as Array<{
-          id: number;
-          full_name: string;
-          pushed_at?: string;
-        }>,
-      );
+      if (!res.ok) throw new Error("Failed to fetch repositories");
+      const data = (await res.json()) as { repositories?: Repo[] };
+      setRepos(data.repositories ?? []);
     } catch {
       toast.error("Failed to load GitHub repositories");
     } finally {
       setIsFetchingRepos(false);
     }
+  }, []);
+
+  useEffect(() => {
+    if (open && selectedInstallationId !== null) {
+      fetchRepositories(selectedInstallationId);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, selectedInstallationId]);
+
+  const handleSearchChange = (value: string) => {
+    setSearchQuery(value);
+    if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+    if (!value.trim()) {
+      setSearchResults(null);
+      return;
+    }
+    searchTimeoutRef.current = setTimeout(async () => {
+      if (!selectedInstallationId) return;
+      setIsSearching(true);
+      try {
+        const res = await fetch(
+          `/api/github/repositories/search?installation_id=${selectedInstallationId}&q=${encodeURIComponent(value.trim())}`,
+        );
+        if (!res.ok) throw new Error("Search failed");
+        const data = (await res.json()) as { repositories?: Repo[] };
+        setSearchResults(data.repositories ?? []);
+      } catch {
+        toast.error("Search failed");
+      } finally {
+        setIsSearching(false);
+      }
+    }, 400);
   };
 
-  const handleConnect = async () => {
-    // Check if the user already has the GitHub App installed on another project.
-    // If so, reuse that installation_id and skip the GitHub redirect entirely.
-    const { data: existingProjects } = await supabase
-      .from("projects")
-      .select("github_installation_id")
-      .not("github_installation_id", "is", null)
-      .neq("id", liveProject.id)
-      .limit(1)
-      .single();
-
-    if (existingProjects?.github_installation_id) {
-      // Already installed - just copy the installation_id to this project
-      // and let the user pick a repo directly.
-      const { error } = await supabase
-        .from("projects")
-        .update({
-          github_installation_id: existingProjects.github_installation_id,
-        })
-        .eq("id", liveProject.id);
-
-      if (!error) {
-        setLiveProject((p) => ({
-          ...p,
-          github_installation_id: existingProjects.github_installation_id,
-        }));
-        fetchRepositories(existingProjects.github_installation_id);
-        return;
-      }
-    }
-
-    // No existing installation - go through the normal GitHub App install flow.
-    // GitHub's Setup URL callback does NOT forward the `state` URL param -
-    // so we persist the projectId in a short-lived cookie before leaving.
-    // The callback route reads it back to know which project to link.
-    document.cookie = `github_oauth_project_id=${liveProject.id}; path=/; max-age=300; SameSite=Lax`;
-
-    const appName = process.env.NEXT_PUBLIC_GITHUB_APP_NAME || "envault";
-    // Navigate the current tab - avoids all popup-blocker issues.
-    window.location.href = `https://github.com/apps/${appName}/installations/new`;
+  const launchGitHub = () => {
+    // Open our new OAuth proxy route which redirects to GitHub's account picker
+    window.open(
+      `/api/github/add-account?project_id=${liveProject.id}`,
+      "_blank",
+      "noopener,noreferrer",
+    );
   };
 
   const handleSelectRepo = async (repoFullName: string) => {
-    setIsLoading(true);
+    setIsLinking(true);
+    setLinkingRepoFullName(repoFullName);
     try {
-      // Prevent the same repo from being linked to more than one project.
-      // If shared, JIT access would auto-grant collaborators access to ALL
-      // linked projects simultaneously - a security risk for prod secrets.
       const { data: conflict } = await supabase
         .from("projects")
         .select("id, name")
@@ -180,9 +249,8 @@ export function GitHubIntegrationDialog({
 
       if (conflict) {
         toast.error(
-          `This repository is already linked to another project ("${conflict.name}"). Each repository can only be linked to one project.`,
+          `"${repoFullName}" is already linked to "${conflict.name}". Each repository can only be linked to one project.`,
         );
-        setIsLoading(false);
         return;
       }
 
@@ -193,18 +261,31 @@ export function GitHubIntegrationDialog({
 
       if (error) throw error;
 
+      // Audit: repo linked (client-side fire-and-forget via API)
+      fetch("/api/audit/github", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "github.repo_linked",
+          projectId: liveProject.id,
+          metadata: { repo_full_name: repoFullName },
+        }),
+      }).catch(() => {});
+
       setLiveProject((p) => ({ ...p, github_repo_full_name: repoFullName }));
-      toast.success("Repository linked successfully!");
+      toast.success("Repository linked!");
       router.refresh();
     } catch {
       toast.error("Failed to link repository");
     } finally {
-      setIsLoading(false);
+      setIsLinking(false);
+      setLinkingRepoFullName(null);
     }
   };
 
   const handleUnlink = async () => {
-    setIsLoading(true);
+    const prevRepo = liveProject.github_repo_full_name;
+    setIsLinking(true);
     try {
       const { error } = await supabase
         .from("projects")
@@ -213,174 +294,345 @@ export function GitHubIntegrationDialog({
 
       if (error) throw error;
 
-      // Only clear the repo name - keep the installation ID so the dialog goes
-      // back to repo-selection state instead of needing a new GitHub OAuth flow.
+      // Audit: repo unlinked
+      fetch("/api/audit/github", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "github.repo_unlinked",
+          projectId: liveProject.id,
+          metadata: { repo_full_name: prevRepo, reason: "manual" },
+        }),
+      }).catch(() => {});
+
       setLiveProject((p) => ({ ...p, github_repo_full_name: null }));
       toast.success("Repository unlinked");
       router.refresh();
-      // Immediately reload repos so the user can pick a new one
-      if (liveProject.github_installation_id) {
-        fetchRepositories(liveProject.github_installation_id);
-      }
+      if (selectedInstallationId) fetchRepositories(selectedInstallationId);
     } catch {
       toast.error("Failed to unlink repository");
     } finally {
-      setIsLoading(false);
+      setIsLinking(false);
     }
   };
 
+  const selectedInstallation = installations.find(
+    (i) => i.installation_id === selectedInstallationId,
+  );
+
+  const displayedRepos = searchQuery.trim() ? (searchResults ?? []) : repos;
+  const hasSelectedRepo = !!liveProject.github_repo_full_name;
+  const hasInstallations = installations.length > 0;
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[95vw] max-w-md sm:w-full max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <Github className="h-5 w-5" />
-            GitHub Integration
-          </DialogTitle>
-          <DialogDescription>
-            Link a GitHub repository to automatically grant access to
-            collaborators when they run{" "}
-            <code className="bg-muted px-1 py-0.5 rounded">envault pull</code>.
-          </DialogDescription>
-        </DialogHeader>
+    <TooltipProvider delayDuration={200}>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="w-[95vw] max-w-md sm:w-full flex flex-col max-h-[90dvh] gap-0 p-0 overflow-hidden">
+          <DialogHeader className="px-6 pt-6 pb-4 shrink-0">
+            <DialogTitle className="flex items-center gap-2">
+              <Github className="h-5 w-5" />
+              GitHub Integration
+            </DialogTitle>
+            <DialogDescription className="text-sm leading-relaxed">
+              Link a repository from your GitHub account. Once linked,
+              collaborators on that repository who run{" "}
+              <code className="bg-muted px-1 py-0.5 rounded text-xs font-mono">
+                envault pull
+              </code>{" "}
+              are automatically granted read access - Envault verifies their
+              GitHub identity automatically.
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="py-4">
-          {!isLinked && (
-            <div className="flex flex-col items-center justify-center space-y-4 text-center p-4 sm:p-6 border rounded-lg bg-muted/30">
-              <div className="bg-background p-3 rounded-full shadow-sm border">
-                <Github className="h-8 w-8 text-muted-foreground" />
-              </div>
-              <div className="space-y-1">
-                <h4 className="font-medium">No repository linked</h4>
-                <p className="text-sm text-muted-foreground">
-                  Install the Envault GitHub App to enable Just-in-Time access
-                  for your team.
-                </p>
-              </div>
-              <Button onClick={handleConnect} className="w-full sm:w-auto">
-                <LinkIcon className="mr-2 h-4 w-4" />
-                Connect GitHub Repository
-              </Button>
-            </div>
-          )}
-
-          {needsRepoSelection && (
-            <div className="space-y-4">
-              <div className="flex items-center gap-2 text-amber-600 bg-amber-50 dark:bg-amber-950/30 p-3 rounded-md border border-amber-200 dark:border-amber-900">
-                <AlertCircle className="h-5 w-5 shrink-0" />
-                <p className="text-sm">
-                  App installed! Please select the specific repository to link
-                  to this project.
-                </p>
-              </div>
-
-              <div className="border rounded-md divide-y max-h-[200px] overflow-y-auto">
-                {isFetchingRepos ? (
-                  <div className="divide-y">
-                    {Array.from({ length: 4 }).map((_, i) => (
-                      <div
-                        key={i}
-                        className="flex items-center justify-between p-3"
-                      >
-                        <div className="flex flex-col gap-1.5">
-                          <Skeleton className="h-3.5 w-40" />
-                          <Skeleton className="h-3 w-20" />
-                        </div>
-                        <Skeleton className="h-8 w-16 rounded-md" />
-                      </div>
-                    ))}
-                  </div>
-                ) : repos.length === 0 ? (
-                  <div className="p-4 text-center text-sm text-muted-foreground">
-                    No repositories found. Make sure you granted access to the
-                    correct repositories during installation.
-                  </div>
-                ) : (
-                  repos.map((repo) => (
-                    <div
-                      key={repo.id}
-                      className="flex items-center justify-between gap-3 p-3 hover:bg-muted/50 transition-colors"
-                    >
-                      <div className="flex flex-col min-w-0">
-                        <span className="text-sm font-medium truncate">
-                          {repo.full_name}
-                        </span>
-                        {repo.pushed_at && (
-                          <span className="text-xs text-muted-foreground">
-                            last commit {formatRelativeTime(repo.pushed_at)}
-                          </span>
-                        )}
-                      </div>
-                      <Button
-                        size="sm"
-                        variant="secondary"
-                        className="shrink-0"
-                        onClick={() => handleSelectRepo(repo.full_name)}
-                        disabled={isLoading}
-                      >
-                        Select
-                      </Button>
-                    </div>
-                  ))
-                )}
-              </div>
-            </div>
-          )}
-
-          {isLinked && hasSelectedRepo && (
-            <div className="space-y-4">
-              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-4 border rounded-lg bg-green-50/50 dark:bg-green-950/20 border-green-200 dark:border-green-900">
-                <div className="flex items-center gap-3 min-w-0">
-                  <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600 dark:text-green-500" />
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-green-900 dark:text-green-100">
-                      Successfully Linked
-                    </p>
-                    <p className="text-sm text-green-700 dark:text-green-400 font-mono mt-0.5 truncate">
-                      {liveProject.github_repo_full_name}
-                    </p>
-                  </div>
+          {/* Scrollable body */}
+          <div className="flex-1 overflow-y-auto overflow-x-hidden px-6 pb-4 space-y-4">
+            {/* No GitHub App connected */}
+            {!hasInstallations && !isFetchingInstallations && (
+              <div className="flex flex-col items-center justify-center space-y-4 text-center p-6 border rounded-lg bg-muted/30">
+                <div className="bg-background p-3 rounded-full shadow-sm border">
+                  <Github className="h-8 w-8 text-muted-foreground" />
                 </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleUnlink}
-                  disabled={isLoading}
-                  className="shrink-0 w-full sm:w-auto text-destructive hover:text-destructive hover:bg-destructive/10"
-                >
-                  {isLoading ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Unlink className="h-4 w-4 mr-2" />
-                  )}
-                  Unlink
+                <div className="space-y-1">
+                  <h4 className="font-medium">No GitHub account connected</h4>
+                  <p className="text-sm text-muted-foreground">
+                    Install the Envault GitHub App on your personal account or
+                    organisation to get started.
+                  </p>
+                </div>
+                <Button onClick={launchGitHub} className="w-full sm:w-auto">
+                  <LinkIcon className="mr-2 h-4 w-4" />
+                  Connect GitHub Account
                 </Button>
               </div>
-              <p className="text-sm text-muted-foreground">
-                Anyone who is a collaborator on{" "}
-                <strong className="break-all">
-                  {liveProject.github_repo_full_name}
-                </strong>{" "}
-                will automatically be granted Viewer access when they run{" "}
-                <code className="bg-muted px-1 py-0.5 rounded">
-                  envault pull
-                </code>
-                .
-              </p>
-            </div>
-          )}
-        </div>
+            )}
 
-        <DialogFooter>
-          <Button
-            variant="outline"
-            className="w-full sm:w-auto"
-            onClick={() => onOpenChange(false)}
-          >
-            Close
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+            {/* Accounts loading */}
+            {isFetchingInstallations && !hasInstallations && (
+              <div className="space-y-2">
+                <Skeleton className="h-3.5 w-28" />
+                <AccountSkeletons />
+              </div>
+            )}
+
+            {/* Account switcher + repo UI */}
+            {hasInstallations && (
+              <>
+                {/* Account selector */}
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                      GitHub Account
+                    </p>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 gap-1 text-xs"
+                          onClick={launchGitHub}
+                        >
+                          <Plus className="h-3.5 w-3.5" />
+                          Add account
+                          <ExternalLink className="h-3 w-3 opacity-50" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent
+                        side="left"
+                        className="max-w-[220px] text-center"
+                      >
+                        Opens GitHub in a new tab. Make sure you are signed into
+                        the correct account first.
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {installations.map((inst) => (
+                      <button
+                        key={inst.installation_id}
+                        onClick={() =>
+                          setSelectedInstallationId(inst.installation_id)
+                        }
+                        className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border transition-colors ${
+                          selectedInstallationId === inst.installation_id
+                            ? "bg-primary text-primary-foreground border-primary"
+                            : "bg-background text-foreground border-border hover:bg-muted"
+                        }`}
+                      >
+                        <Github className="h-3.5 w-3.5 shrink-0" />
+                        <span className="truncate max-w-[120px]">
+                          {inst.account_login ??
+                            `Installation ${inst.installation_id}`}
+                        </span>
+                        {inst.account_type === "Organization" && (
+                          <Building2 className="h-3 w-3 shrink-0 opacity-70" />
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Linked repo status */}
+                {hasSelectedRepo && (
+                  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-4 border rounded-lg bg-green-50/50 dark:bg-green-950/20 border-green-200 dark:border-green-900">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600 dark:text-green-500" />
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-green-900 dark:text-green-100">
+                          Linked Repository
+                        </p>
+                        <p className="text-sm text-green-700 dark:text-green-400 font-mono mt-0.5 truncate">
+                          {liveProject.github_repo_full_name}
+                        </p>
+                      </div>
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleUnlink}
+                      disabled={isLinking}
+                      className="shrink-0 w-full sm:w-auto text-destructive hover:text-destructive hover:bg-destructive/10"
+                    >
+                      {isLinking ? (
+                        <Skeleton className="h-4 w-16" />
+                      ) : (
+                        <>
+                          <Unlink className="h-4 w-4 mr-2" />
+                          Unlink
+                        </>
+                      )}
+                    </Button>
+                  </div>
+                )}
+
+                {/* Prompt to pick a repo, Search bar and Repo list (only visible if NO repo is linked) */}
+                {!hasSelectedRepo && (
+                  <>
+                    <div className="flex items-start gap-2 text-amber-600 bg-amber-50 dark:bg-amber-950/30 p-3 rounded-md border border-amber-200 dark:border-amber-900">
+                      <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+                      <p className="text-sm">
+                        Select a repository below to link it to this project.
+                      </p>
+                    </div>
+
+                    {/* Search bar - stopPropagation prevents 'v' hotkey from firing */}
+                    <div className="relative">
+                      <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+                      {searchQuery && (
+                        <button
+                          className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                          onClick={() => {
+                            setSearchQuery("");
+                            setSearchResults(null);
+                          }}
+                          aria-label="Clear search"
+                        >
+                          <X className="h-4 w-4" />
+                        </button>
+                      )}
+                      <Input
+                        placeholder="Search repositories…"
+                        className="pl-9 pr-8"
+                        value={searchQuery}
+                        onChange={(e) => handleSearchChange(e.target.value)}
+                        // Prevent global hotkeys (e.g. 'v' = toggle value visibility)
+                        // from intercepting keystrokes inside this input.
+                        onKeyDown={(e) => e.stopPropagation()}
+                      />
+                    </div>
+
+                    {/* Repository list */}
+                    <div className="border rounded-md overflow-hidden">
+                      {isFetchingRepos || isSearching ? (
+                        <RepoSkeletons />
+                      ) : displayedRepos.length === 0 ? (
+                        <div className="p-6 text-center text-sm text-muted-foreground">
+                          {searchQuery.trim()
+                            ? `No repositories found for "${searchQuery}".`
+                            : "No repositories found. Make sure you granted access during installation."}
+                        </div>
+                      ) : (
+                        <div className="max-h-[240px] overflow-y-auto overflow-x-hidden divide-y">
+                          {displayedRepos.map((repo) => {
+                            const isCollaborator =
+                              selectedInstallation?.account_login &&
+                              repo.owner_login &&
+                              repo.owner_login.toLowerCase() !==
+                                selectedInstallation.account_login.toLowerCase();
+
+                            return (
+                              <div
+                                key={repo.id}
+                                className="flex items-center justify-between gap-2 p-3 hover:bg-muted/50 transition-colors"
+                              >
+                                <div className="flex flex-col min-w-0 flex-1">
+                                  <div className="flex items-center gap-1.5 min-w-0">
+                                    <span className="text-sm font-medium truncate">
+                                      {repo.full_name}
+                                    </span>
+                                    <div className="flex items-center gap-1 shrink-0">
+                                      {repo.private && (
+                                        <Tooltip>
+                                          <TooltipTrigger asChild>
+                                            <Lock
+                                              className="h-3.5 w-3.5 text-amber-500 cursor-default"
+                                              aria-label="Private Repository"
+                                            />
+                                          </TooltipTrigger>
+                                          <TooltipContent>
+                                            Private Repository
+                                          </TooltipContent>
+                                        </Tooltip>
+                                      )}
+                                      {repo.fork && (
+                                        <Tooltip>
+                                          <TooltipTrigger asChild>
+                                            <GitFork
+                                              className="h-3.5 w-3.5 text-blue-500 cursor-default"
+                                              aria-label="Forked Repository"
+                                            />
+                                          </TooltipTrigger>
+                                          <TooltipContent>
+                                            Forked Repository
+                                          </TooltipContent>
+                                        </Tooltip>
+                                      )}
+                                      {isCollaborator && (
+                                        <Tooltip>
+                                          <TooltipTrigger asChild>
+                                            <Users
+                                              className="h-3.5 w-3.5 text-purple-500 cursor-default"
+                                              aria-label="You are a collaborator"
+                                            />
+                                          </TooltipTrigger>
+                                          <TooltipContent>
+                                            You are a collaborator
+                                          </TooltipContent>
+                                        </Tooltip>
+                                      )}
+                                    </div>
+                                  </div>
+                                  {repo.pushed_at && (
+                                    <span className="text-xs text-muted-foreground">
+                                      last commit{" "}
+                                      {formatRelativeTime(repo.pushed_at)}
+                                    </span>
+                                  )}
+                                </div>
+                                <Button
+                                  size="sm"
+                                  variant={"secondary"}
+                                  className="shrink-0"
+                                  onClick={() =>
+                                    handleSelectRepo(repo.full_name)
+                                  }
+                                  disabled={isLinking}
+                                >
+                                  {isLinking &&
+                                  linkingRepoFullName === repo.full_name
+                                    ? "Linking..."
+                                    : "Select"}
+                                </Button>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  </>
+                )}
+
+                {/* Contextual footer info */}
+                {hasSelectedRepo && (
+                  <p className="text-sm text-muted-foreground">
+                    GitHub collaborators on{" "}
+                    <strong className="break-all font-mono text-xs">
+                      {liveProject.github_repo_full_name}
+                    </strong>{" "}
+                    can run{" "}
+                    <code className="bg-muted px-1 py-0.5 rounded text-xs font-mono">
+                      envault pull
+                    </code>{" "}
+                    to instantly receive read access - Envault verifies their
+                    GitHub identity automatically.
+                  </p>
+                )}
+              </>
+            )}
+          </div>
+
+          <DialogFooter className="px-6 py-4 border-t shrink-0">
+            <Button
+              variant="outline"
+              className="w-full sm:w-auto"
+              onClick={() => {
+                onOpenChange(false);
+              }}
+            >
+              Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </TooltipProvider>
   );
 }

--- a/src/components/ui/scroll-progress.tsx
+++ b/src/components/ui/scroll-progress.tsx
@@ -31,7 +31,8 @@ export function ScrollProgress({
     return () => window.removeEventListener("scroll", handleScroll);
   }, [externalProgress]);
 
-  const progress = externalProgress !== undefined ? externalProgress : windowProgress;
+  const progress =
+    externalProgress !== undefined ? externalProgress : windowProgress;
   const radius = (size - strokeWidth * 2) / 2;
   const circumference = 2 * Math.PI * radius;
   const cx = size / 2;
@@ -58,7 +59,7 @@ export function ScrollProgress({
         strokeWidth={strokeWidth}
         opacity={0.5}
       />
-      {/* Progress — starts at 12 o’clock via rotate(-90) */}
+      {/* Progress - starts at 12 o’clock via rotate(-90) */}
       <g transform={`rotate(-90, ${cx}, ${cy})`}>
         <motion.circle
           cx={cx}
@@ -71,7 +72,12 @@ export function ScrollProgress({
           strokeDasharray={circumference}
           initial={{ strokeDashoffset: circumference * (1 - progress) }}
           animate={{ strokeDashoffset: circumference * (1 - progress) }}
-          transition={{ type: "spring", stiffness: 120, damping: 30, mass: 0.5 }}
+          transition={{
+            type: "spring",
+            stiffness: 120,
+            damping: 30,
+            mass: 0.5,
+          }}
         />
       </g>
     </svg>

--- a/src/lib/stores/store.ts
+++ b/src/lib/stores/store.ts
@@ -23,7 +23,6 @@ export type Project = {
   ui_mode?: "simple" | "advanced";
   default_environment_slug?: string;
   active_environment_slug?: string;
-  github_installation_id?: number | null;
   github_repo_full_name?: string | null;
   environments?: Array<{
     id: string;

--- a/src/lib/system/audit-logger.ts
+++ b/src/lib/system/audit-logger.ts
@@ -22,7 +22,11 @@ export type AuditLogAction =
   | "transfer.accepted"
   | "transfer.rejected"
   | "environment.access_granted"
-  | "environment.access_revoked";
+  | "environment.access_revoked"
+  | "github.account_connected"
+  | "github.account_disconnected"
+  | "github.repo_linked"
+  | "github.repo_unlinked";
 
 export interface AuditLogPayload {
   projectId: string;

--- a/src/lib/system/changelog-parser.ts
+++ b/src/lib/system/changelog-parser.ts
@@ -79,7 +79,7 @@ function normalizeCategory(value: string): string | null {
 }
 
 function detectCategory(heading: string, body: string): string {
-  // Optional explicit override in heading: "## 1.2.1 — 2026-03-10 [Security]"
+  // Optional explicit override in heading: "## 1.2.1 - 2026-03-10 [Security]"
   const explicitMatch = heading.match(/\[([a-z ]+)\]/i);
   if (explicitMatch) {
     const explicit = normalizeCategory(explicitMatch[1]);
@@ -126,7 +126,7 @@ export function parseChangelog(): ChangelogEntry[] {
   const changelogPath = path.join(process.cwd(), "CHANGELOG.md");
   const raw = fs.readFileSync(changelogPath, "utf-8");
 
-  // Split on ## headings — each is one release
+  // Split on ## headings - each is one release
   const sections = raw.split(/^## /m).filter(Boolean);
 
   const entries: ChangelogEntry[] = [];
@@ -135,7 +135,7 @@ export function parseChangelog(): ChangelogEntry[] {
     const lines = section.split("\n");
     const heading = lines[0].trim();
 
-    // Matches "1.3.0 — 2026-03-09" or "1.3.0" or "1.3.0 (2026-03-09)"
+    // Matches "1.3.0 - 2026-03-09" or "1.3.0" or "1.3.0 (2026-03-09)"
     const versionMatch = heading.match(/^(\d+\.\d+\.\d+)/);
     if (!versionMatch) continue;
 

--- a/supabase/migrations/20260318000000_create_github_installations.sql
+++ b/supabase/migrations/20260318000000_create_github_installations.sql
@@ -1,0 +1,31 @@
+-- Create per-user GitHub App installations table (1-to-many relationship)
+-- This replaces the single github_installation_id column on the projects table.
+-- A project retains github_repo_full_name (which repo is linked) while the
+-- installation itself is resolved through this table.
+
+CREATE TABLE IF NOT EXISTS public.github_installations (
+  id              BIGSERIAL PRIMARY KEY,
+  user_id         UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  installation_id BIGINT NOT NULL,
+  account_login   TEXT,        -- GitHub username or org name for display
+  account_type    TEXT,        -- 'User' or 'Organization'
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (user_id, installation_id)
+);
+
+ALTER TABLE public.github_installations ENABLE ROW LEVEL SECURITY;
+
+-- Users can only see and manage their own installations
+CREATE POLICY "Users manage own installations"
+  ON public.github_installations
+  FOR ALL
+  USING ((SELECT auth.uid()) = user_id);
+
+CREATE INDEX IF NOT EXISTS idx_github_installations_user_id
+  ON public.github_installations (user_id);
+
+-- Remove the now-redundant column from projects.
+-- Projects keep github_repo_full_name (which repo is linked).
+-- The installation is resolved through github_installations.
+ALTER TABLE public.projects
+  DROP COLUMN IF EXISTS github_installation_id;


### PR DESCRIPTION
## Summary
- route Add Account through GitHub OAuth first so users can choose the correct identity before App installation
- support multiple per-user GitHub installations, account switching, repository search, and safer linked-repo UX in the integration dialog
- expand GitHub audit coverage end-to-end (`github.account_connected`, `github.account_disconnected`, `github.repo_linked`, `github.repo_unlinked`) with server-side logging and webhook cleanup
- add `/api/audit/github` secure audit endpoint and include GitHub actions in audit-log API filters and UI rendering with descriptive details
- document the updated GitHub integration flow, audit events, and required environment variables

## Validation
- npm run lint
- npx -y tsc --noEmit

Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>
