### PR TITLE
Refine changelog timeline pagination UI and mobile spacing

### DIFF
--- a/src/components/changelog/ChangelogTimeline.tsx
+++ b/src/components/changelog/ChangelogTimeline.tsx
@@ -574,7 +574,6 @@ export function ChangelogTimeline({ entries }: TimelineProps) {
           // Browser scroll completely paralyzed mid-way! Force UI payload dynamically and snap instantly.
           setCurrentPage(targetPageRef.current);
           setTargetPage(null);
-          // @ts-ignore
           window.scrollTo({ top: 0, behavior: "instant" });
           return;
         }


### PR DESCRIPTION
## Summary
Updates the pagination in the changelog timeline to replace the old `Page X of Y` display with a cleaner numbered pager while keeping the existing `Previous` and `Next` buttons.

## Changes
- Added numbered pagination pills for changelog pages
- Kept the original `Previous` / `Next` button styling
- Reduced the size of the page numbers and active pill
- Adjusted spacing so the pager reads more evenly, including the `1 2 / 2` layout
- Improved responsive behavior so pagination stays cleaner on mobile

## Why
The previous pagination felt too plain and took up more visual attention than necessary. This change makes the pager feel lighter, more intentional, and easier to scan across desktop and mobile.

## Validation
- Ran `cmd /c npx eslint src\components\changelog\ChangelogTimeline.tsx`