### PR TITLE
Update account deletion documentation and environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,7 @@ EMAIL_DOMAIN=your_configured_email
 
 ## HMAC Secret for API Request Signing
 NEXT_PUBLIC_API_SIGNATURE_SALT=your_secure_random_hmac_secret_here
+
+## Cron Secrets
+ACCOUNT_DELETION_CRON_SECRET=your_secure_random_string_for_account_deletion_cron_here
+ROTATE_KEYS_CRON_SECRET=your_secure_random_string_for_rotate_keys_cron_here

--- a/content/docs/core/access-control.mdx
+++ b/content/docs/core/access-control.mdx
@@ -94,9 +94,13 @@ This visibility enables collaborative teams to maintain security awareness and a
 
 When a member deletes their account, Envault preserves project integrity and attribution context:
 
+- **Deletion is scheduled (soft-delete)** for a 7-day grace period instead of immediate hard deletion.
+- **Signing back in during the grace window cancels deletion** and restores normal account status.
 - **Shared secrets are not deleted** during account removal.
 - **Ownership pointers are safely reassigned** to the project owner where required.
 - **Creator/updater identity snapshots are retained** on secret records so project history remains understandable in variable tables and audit timelines.
+
+After the grace window expires, automated purge jobs permanently remove the account and clean up linked user-scoped records.
 
 If a live user profile can no longer be resolved, UI surfaces a fallback identity label while preserving available metadata from prior snapshots.
 

--- a/content/docs/core/notifications.mdx
+++ b/content/docs/core/notifications.mdx
@@ -27,7 +27,7 @@ Preferences are grouped into seven matched categories for email and in‑app cha
 | <UserPlus className="inline w-4 h-4 mr-1" /> Access Requests                   | `access_request_received`                                                                        | same         |
 | <CheckCircle2 className="inline w-4 h-4 mr-1" /> Access Granted / Role Changes | approvals, denials, invitations, membership changes                                              | same         |
 | <Smartphone className="inline w-4 h-4 mr-1" /> Device Activity                 | new device access, new location, unknown login                                                   | same         |
-| <ShieldAlert className="inline w-4 h-4 mr-1" /> Security Alerts                | password/email changes, 2FA events, encryption failures, security advisories                     | same         |
+| <ShieldAlert className="inline w-4 h-4 mr-1" /> Security Alerts                | password/email changes, 2FA events, encryption failures, security advisories, account deletion scheduled | same         |
 | <FolderPlus className="inline w-4 h-4 mr-1" /> Project Activity                | secrets added/updated/deleted, bulk ops, project CRUD, settings changes, members joining/leaving | same         |
 | <Terminal className="inline w-4 h-4 mr-1" /> CLI Activity                      | `secrets_pulled`, `secrets_pushed`                                                               | same         |
 | <ServerCrash className="inline w-4 h-4 mr-1" /> System Updates                 | system releases, maintenance notices, rate‑limit warnings, email failures                        | same         |
@@ -111,6 +111,16 @@ If users do not receive expected email notifications:
 3. Check mail logs for bounces or rate‑limit errors (also surfaced as `email_failed` notifications in‑app).
 
 For high‑volume installations, review the `supabase/migrations/20260224000001_expand_notification_preferences.sql` migration, which adds the granular preference columns and sets secure defaults.
+
+## Account Deletion Emails
+
+When account deletion is requested from Settings, Envault sends a security email that includes:
+
+- The deletion request time.
+- The permanent deletion deadline (7 days later).
+- A sign-in action link to cancel deletion before the deadline.
+
+If the user timezone is unavailable, timestamps are shown in UTC.
 
 ---
 

--- a/content/docs/guides/production-deployment.mdx
+++ b/content/docs/guides/production-deployment.mdx
@@ -20,6 +20,9 @@ Before deploying, ensure you have the following environment variables configured
 | `ENCRYPTION_KEY` | 32-byte hex string for Master Key | Yes |
 | `NEXT_PUBLIC_SITE_URL` | The URL where your app is hosted (e.g. `https://envault.app`) | Yes |
 | `NEXT_PUBLIC_APP_URL` | Same as `NEXT_PUBLIC_SITE_URL` - used for GitHub callback redirects | Yes |
+| `CRON_SECRET` | Secret used by `/api/cron/digest` email digest endpoint | For notification digests |
+| `ACCOUNT_DELETION_CRON_SECRET` | Secret header validation for `process-account-deletions` Edge Function | Yes (recommended for production) |
+| `ROTATE_KEYS_CRON_SECRET` | Secret header validation for `rotate-keys` Edge Function | Yes (recommended for production) |
 | `ENVAULT_GITHUB_APP_CLIENT_ID` | GitHub App Client ID | For GitHub Integration |
 | `ENVAULT_GITHUB_APP_CLIENT_SECRET` | GitHub App Client Secret | For GitHub Integration |
 | `ENVAULT_GITHUB_APP_PRIVATE_KEY` | RSA private key, single-line `\n`-escaped | For GitHub Integration |
@@ -105,3 +108,20 @@ Before deploying, ensure you have the following environment variables configured
 - **HTTPS**: Ensure your domain is serving over HTTPS.
 - **Database Backups**: Enable Point-in-Time Recovery (PITR) on Supabase.
 - **Key Backup**: Securely back up your `ENCRYPTION_KEY` in a password manager. If you lose this, all data is lost.
+
+### Required Scheduled Jobs
+
+Configure these recurring jobs after deploy:
+
+1. **Email Digest Cron** (`/api/cron/digest`)
+  - Send authenticated `GET` requests with `Authorization: Bearer <CRON_SECRET>`.
+2. **Account Deletion Purge** (`supabase/functions/v1/process-account-deletions`)
+  - Trigger daily with `x-cron-secret: <ACCOUNT_DELETION_CRON_SECRET>`.
+3. **Key Rotation / Scavenger** (`supabase/functions/v1/rotate-keys`)
+  - Trigger with `x-cron-secret: <ROTATE_KEYS_CRON_SECRET>` on your desired cadence.
+
+<Callout type="info">
+  For Supabase-hosted schedules, use the SQL migration templates under
+  `supabase/migrations` and replace the placeholder cron secrets before
+  applying in production.
+</Callout>

--- a/src/app/(marketing)/privacy/page.tsx
+++ b/src/app/(marketing)/privacy/page.tsx
@@ -35,7 +35,7 @@ export default async function PrivacyPage() {
   return (
     <LegalLayout
       title="Privacy Policy"
-      lastUpdated="24 February 2026"
+      lastUpdated="30 March 2026"
       sections={sections}
     >
       <section
@@ -350,6 +350,11 @@ export default async function PrivacyPage() {
             that cannot be disabled, such as account access from new devices.
           </li>
           <li className="leading-relaxed">
+            <strong>Account Deletion Notices</strong>: When account deletion is
+            requested, we send a transactional security email with the request
+            time, scheduled deletion deadline, and recovery instructions.
+          </li>
+          <li className="leading-relaxed">
             <strong>Service Communications</strong>: Updates about new features,
             maintenance, or policy changes.
           </li>
@@ -469,8 +474,11 @@ export default async function PrivacyPage() {
           <ul className="space-y-3 text-muted-foreground">
             <li className="leading-relaxed">
               <strong className="text-foreground">Account Data</strong>:
-              Retained for the duration of your account. Deleted within 30 days
-              of account deletion, except where required for legal compliance.
+              Retained for the duration of your account. When deletion is
+              requested, account data enters a 7-day soft-delete window and is
+              permanently purged after the grace period unless you sign back in
+              to revive the account. Limited records may be retained longer
+              where required for legal compliance.
             </li>
             <li className="leading-relaxed">
               <strong className="text-foreground">Encrypted Secrets</strong>:

--- a/src/app/(marketing)/terms/page.tsx
+++ b/src/app/(marketing)/terms/page.tsx
@@ -39,7 +39,7 @@ export default async function TermsPage() {
   return (
     <LegalLayout
       title="Terms of Service"
-      lastUpdated="24 February 2026"
+      lastUpdated="30 March 2026"
       sections={sections}
     >
       <section
@@ -84,6 +84,11 @@ export default async function TermsPage() {
           responsibility to maintain account security. If you link multiple
           OAuth providers, you agree that any linked provider can be used to
           access your account.
+        </p>
+        <p className="text-muted-foreground mt-4 leading-relaxed">
+          If you request account deletion, Envault applies a 7-day soft-delete
+          grace period before permanent deletion. Signing back in during this
+          period revives your account and cancels pending deletion.
         </p>
       </section>
 
@@ -409,6 +414,11 @@ export default async function TermsPage() {
             for account protection.
           </li>
           <li>
+            Account deletion scheduling notices may be sent as transactional
+            security emails, including the deletion deadline and revival
+            instructions.
+          </li>
+          <li>
             You agree that we may send service announcements and updates via
             email or in-app notifications.
           </li>
@@ -450,8 +460,10 @@ export default async function TermsPage() {
           We may terminate or suspend your account immediately, without prior
           notice or liability, for any reason whatsoever, including without
           limitation if you breach the Terms. Upon termination, your right to
-          use the Service will immediately cease. If you wish to terminate your
-          account, you may simply discontinue using the Service.
+          use the Service will immediately cease. If you request account
+          deletion through the Service, deletion is scheduled with a 7-day
+          grace period and may be canceled by signing back in during that
+          window.
         </p>
       </section>
 


### PR DESCRIPTION
This pull request updates documentation and legal pages to clarify the account deletion process, notification policies, and required production environment variables for scheduled jobs. The main focus is on introducing and explaining a 7-day soft-delete grace period for account deletion, updating notification descriptions, and adding relevant configuration and operational guidance.

**Account Deletion Policy and Notification Updates:**

* Added detailed explanation of the 7-day soft-delete grace period for account deletion, including the ability to cancel deletion by signing in during the grace window, and clarified timing of permanent deletion and data retention in documentation and legal pages (`content/docs/core/access-control.mdx`, `src/app/(marketing)/privacy/page.tsx`, `src/app/(marketing)/terms/page.tsx`). 

**Production Deployment and Environment Configuration:**

* Added new environment variables for scheduled jobs related to account deletion and key rotation (`ACCOUNT_DELETION_CRON_SECRET`, `ROTATE_KEYS_CRON_SECRET`, `CRON_SECRET`) to `.env.example` and updated production deployment documentation to describe their use and required scheduled job setup (`.env.example`, `content/docs/guides/production-deployment.mdx`). 

**Legal Page Updates:**

* Updated "last updated" dates on Privacy Policy and Terms of Service pages to reflect recent changes (`src/app/(marketing)/privacy/page.tsx`, `src/app/(marketing)/terms/page.tsx`). 

These changes ensure users and administrators are clearly informed about the account deletion workflow, notification triggers, and necessary operational setup for production environments.

---
Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>