### PR TITLE
Update Homebrew and Cask configurations for Envault CLI

### DIFF
--- a/cli-go/.goreleaser.yaml
+++ b/cli-go/.goreleaser.yaml
@@ -7,7 +7,8 @@ before:
     - go mod tidy
 
 builds:
-  - env:
+  - id: envault
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
@@ -23,7 +24,10 @@ builds:
       - -X github.com/DinanathDash/Envault/cli-go/cmd.date={{.Date}}
 
 archives:
-  - formats:
+  - id: cli-tarballs
+    ids:
+      - envault
+    formats:
       - tar.gz
     # this name template makes the OS and Arch compatible with the results of uname.
     name_template: >-
@@ -38,6 +42,18 @@ archives:
       - goos: windows
         formats:
           - zip
+  - id: cli-cask-zips
+    ids:
+      - envault
+    formats:
+      - zip
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
 
 checksum:
   name_template: 'checksums.txt'
@@ -61,6 +77,27 @@ changelog:
       - '^docs:'
       - '^test:'
 
+# Homebrew formula configuration
+brews:
+  - repository:
+      owner: DinanathDash
+      name: homebrew-envault
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    name: envault
+    homepage: "https://envault.tech"
+    description: "Envault CLI - Securely manage your environment variables"
+    license: "Apache-2.0"
+    ids:
+      - cli-tarballs
+    commit_author:
+      name: github-actions[bot]
+      email: 41898282+github-actions[bot]@users.noreply.github.com
+    install: |
+      bin.install "envault"
+    test: |
+      system "#{bin}/envault", "--version"
+
 # Homebrew cask configuration
 homebrew_casks:
   - repository:
@@ -71,5 +108,11 @@ homebrew_casks:
     name: envault
     homepage: "https://envault.tech"
     description: "Envault CLI - Securely manage your environment variables"
+    ids:
+      - cli-cask-zips
+    commit_author:
+      name: github-actions[bot]
+      email: 41898282+github-actions[bot]@users.noreply.github.com
+    binary: envault
     url:
       verified: github.com/DinanathDash/Envault


### PR DESCRIPTION
This pull request updates the `cli-go/.goreleaser.yaml` configuration to improve the build and release process for the Envault CLI, especially around packaging and distribution via Homebrew. The main changes introduce explicit build and archive IDs, add Homebrew formula and cask publishing automation, and refine artifact naming and selection.

Build and archive configuration improvements:
* Added explicit `id` fields to the `builds` and `archives` sections, enabling more precise artifact selection and mapping for downstream packaging steps. (`envault` build ID, `cli-tarballs` and `cli-cask-zips` archive IDs) 

Homebrew publishing automation:
* Introduced a new `brews` section to automate publishing a Homebrew formula for the CLI, including repository, metadata, install, and test instructions. This streamlines Homebrew distribution and ensures up-to-date formulae.
* Enhanced the `homebrew_casks` section to use the new archive ID, set the commit author, and specify the binary for cask installation, improving the cask release process.

---
Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>