### PR TITLE
fix: remove zip format override for Windows in goreleaser configuration

### DIFF
--- a/cli-go/.goreleaser.yaml
+++ b/cli-go/.goreleaser.yaml
@@ -37,11 +37,6 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows
-    format_overrides:
-      - goos: windows
-        formats:
-          - zip
   - id: cli-cask-zips
     ids:
       - envault


### PR DESCRIPTION
This pull request makes a minor update to the `cli-go/.goreleaser.yaml` configuration by removing the format override that used ZIP archives for Windows builds. This means that Windows artifacts will now use the default archive format instead of ZIP.

---
Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>