### PR TITLE
Enforce Homebrew formula-only installation and add diagnostics command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,19 @@ jobs:
         run: |
           npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/npm @semantic-release/git @semantic-release/exec conventional-changelog-conventionalcommits
 
+      - name: Validate Homebrew formula-only release config
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -q "^homebrew_casks:" cli-go/.goreleaser.yaml; then
+            echo "homebrew_casks is not allowed. Envault ships Homebrew formula only."
+            exit 1
+          fi
+          if grep -q "cli-cask-zips" cli-go/.goreleaser.yaml; then
+            echo "cli-cask-zips archive is not allowed in formula-only mode."
+            exit 1
+          fi
+
       - name: Ensure CLI changes exist since last tag
         id: cli_scope
         shell: bash

--- a/README.md
+++ b/README.md
@@ -38,7 +38,14 @@ curl -fsSL https://raw.githubusercontent.com/DinanathDash/Envault/main/install.s
 
 ```bash
 brew tap DinanathDash/envault
-brew install envault
+brew install --formula envault
+```
+
+Homebrew cask installs are deprecated. If you installed via cask, migrate with:
+
+```bash
+brew uninstall --cask dinanathdash/envault/envault
+brew install --formula envault
 ```
 
 For more details, check out the [CLI Documentation](./cli-go/README.md).

--- a/cli-go/.goreleaser.yaml
+++ b/cli-go/.goreleaser.yaml
@@ -37,18 +37,6 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-  - id: cli-cask-zips
-    ids:
-      - envault
-    formats:
-      - zip
-    name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
 
 checksum:
   name_template: 'checksums.txt'
@@ -92,22 +80,3 @@ brews:
       bin.install "envault"
     test: |
       system "#{bin}/envault", "--version"
-
-# Homebrew cask configuration
-homebrew_casks:
-  - repository:
-      owner: DinanathDash
-      name: homebrew-envault
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Casks
-    name: envault
-    homepage: "https://envault.tech"
-    description: "Envault CLI - Securely manage your environment variables"
-    ids:
-      - cli-cask-zips
-    commit_author:
-      name: github-actions[bot]
-      email: 41898282+github-actions[bot]@users.noreply.github.com
-    binary: envault
-    url:
-      verified: github.com/DinanathDash/Envault

--- a/cli-go/README.md
+++ b/cli-go/README.md
@@ -40,7 +40,23 @@ curl -fsSL https://raw.githubusercontent.com/DinanathDash/Envault/main/install.s
 
 ```bash
 brew tap DinanathDash/envault
-brew install envault
+brew install --formula envault
+```
+
+Homebrew cask installs are deprecated. If you previously installed with cask, migrate to formula:
+
+```bash
+brew uninstall --cask dinanathdash/envault/envault
+brew install --formula envault
+```
+
+If Homebrew still resolves an older version, refresh metadata and upgrade explicitly:
+
+```bash
+brew update
+brew untap dinanathdash/envault || true
+brew tap dinanathdash/envault
+brew upgrade --formula envault
 ```
 
 ### Via NPM (Backward Compatible Wrapper)

--- a/cli-go/cmd/audit.go
+++ b/cli-go/cmd/audit.go
@@ -102,7 +102,7 @@ func installPreCommitHook() (alreadyInstalled bool, binPath string, err error) {
 	// Prefer the PATH-based lookup so the hook embeds the stable symlink
 	// (e.g. /opt/homebrew/bin/envault) rather than the versioned Cellar path
 	// (/opt/homebrew/Cellar/envault/1.20.0/bin/envault).  Using the symlink
-	// means the hook survives `brew upgrade envault` without needing
+	// means the hook survives `brew upgrade --formula envault` without needing
 	// re-installation.  Fall back to os.Executable() when not on PATH.
 	execPath, lookErr := exec.LookPath("envault")
 	if lookErr != nil {

--- a/cli-go/cmd/doctor.go
+++ b/cli-go/cmd/doctor.go
@@ -1,0 +1,248 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/DinanathDash/Envault/cli-go/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+type doctorCheck struct {
+	name   string
+	status string
+	detail string
+	fix    []string
+}
+
+type brewFormulaInfo struct {
+	Formulae []struct {
+		Versions struct {
+			Stable string `json:"stable"`
+		} `json:"versions"`
+		Installed []struct {
+			Version string `json:"version"`
+		} `json:"installed"`
+	} `json:"formulae"`
+}
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Run local diagnostics and suggested fixes",
+	Long:  "Diagnose local Envault CLI installation and common Homebrew version mismatch issues.",
+	Run: func(cmd *cobra.Command, args []string) {
+		exePath, err := os.Executable()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, ui.ColorRed("Doctor failed: could not resolve executable path."))
+			os.Exit(1)
+		}
+		exePath, _ = filepath.Abs(exePath)
+		normalizedPath := filepath.ToSlash(exePath)
+		installSource := detectInstallSource(normalizedPath)
+
+		checks := []doctorCheck{
+			{
+				name:   "envault version",
+				status: "ok",
+				detail: fmt.Sprintf("envault v%s", version),
+			},
+			{
+				name:   "executable path",
+				status: "ok",
+				detail: exePath,
+			},
+			{
+				name:   "install source",
+				status: "ok",
+				detail: installSource,
+			},
+		}
+
+		if installSource == "homebrew-cask" {
+			checks = append(checks, doctorCheck{
+				name:   "homebrew cask",
+				status: "warn",
+				detail: "Cask install is deprecated. Envault now uses Homebrew formula only.",
+				fix: []string{
+					"brew uninstall --cask dinanathdash/envault/envault",
+					"brew tap dinanathdash/envault",
+					"brew install --formula envault",
+				},
+			})
+		}
+
+		if isHomebrewPath(normalizedPath) {
+			checks = append(checks, runHomebrewChecks(version)...)
+		}
+
+		hasIssue := false
+		fmt.Println(ui.ColorBold("Envault Doctor"))
+		fmt.Println(ui.ColorDim("Checks local installation and update readiness."))
+		fmt.Println()
+
+		for _, c := range checks {
+			prefix := "[OK]"
+			colorize := ui.ColorGreen
+			if c.status == "warn" {
+				prefix = "[WARN]"
+				colorize = ui.ColorYellow
+				hasIssue = true
+			}
+			if c.status == "error" {
+				prefix = "[ERR]"
+				colorize = ui.ColorRed
+				hasIssue = true
+			}
+			fmt.Printf("%s %s: %s\n", colorize(prefix), c.name, c.detail)
+			if len(c.fix) > 0 {
+				fmt.Println(ui.ColorDim("  Suggested fix:"))
+				for _, line := range c.fix {
+					fmt.Printf("    %s\n", line)
+				}
+			}
+		}
+
+		if hasIssue {
+			fmt.Println()
+			fmt.Println(ui.ColorYellow("Doctor found actionable issues."))
+			os.Exit(1)
+		}
+
+		fmt.Println()
+		fmt.Println(ui.ColorGreen("No issues detected."))
+	},
+}
+
+func runHomebrewChecks(currentVersion string) []doctorCheck {
+	checks := []doctorCheck{}
+
+	if _, err := exec.LookPath("brew"); err != nil {
+		checks = append(checks, doctorCheck{
+			name:   "homebrew binary",
+			status: "warn",
+			detail: "Install appears Homebrew-based but `brew` is not on PATH.",
+		})
+		return checks
+	}
+
+	formulaInfo, err := readBrewFormulaInfo()
+	if err != nil {
+		checks = append(checks, doctorCheck{
+			name:   "homebrew formula metadata",
+			status: "warn",
+			detail: fmt.Sprintf("Could not read formula metadata: %v", err),
+			fix: []string{
+				"brew update",
+				"brew tap dinanathdash/envault",
+			},
+		})
+		return checks
+	}
+
+	latest := "unknown"
+	installed := "not installed"
+	if len(formulaInfo.Formulae) > 0 {
+		latest = strings.TrimSpace(formulaInfo.Formulae[0].Versions.Stable)
+		if len(formulaInfo.Formulae[0].Installed) > 0 {
+			installed = strings.TrimSpace(formulaInfo.Formulae[0].Installed[0].Version)
+		}
+	}
+
+	checks = append(checks, doctorCheck{
+		name:   "homebrew formula",
+		status: "ok",
+		detail: fmt.Sprintf("installed=%s latest=%s", installed, latest),
+	})
+
+	if latest != "" && latest != "unknown" && normalizeVersion(latest) != normalizeVersion(currentVersion) {
+		checks = append(checks, doctorCheck{
+			name:   "version parity",
+			status: "warn",
+			detail: fmt.Sprintf("Current CLI version (%s) differs from formula stable (%s).", currentVersion, latest),
+			fix: []string{
+				"brew update",
+				"brew untap dinanathdash/envault || true",
+				"brew tap dinanathdash/envault",
+				"brew upgrade --formula envault",
+			},
+		})
+	}
+
+	caskInstalled, caskErr := isBrewCaskInstalled()
+	if caskErr == nil && caskInstalled {
+		checks = append(checks, doctorCheck{
+			name:   "deprecated cask detected",
+			status: "warn",
+			detail: "Homebrew cask install is deprecated for Envault.",
+			fix: []string{
+				"brew uninstall --cask dinanathdash/envault/envault",
+				"brew install --formula envault",
+			},
+		})
+	}
+
+	return checks
+}
+
+func readBrewFormulaInfo() (*brewFormulaInfo, error) {
+	cmd := exec.Command("brew", "info", "--json=v2", "--formula", "envault")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var info brewFormulaInfo
+	if err := json.Unmarshal(out, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+func isBrewCaskInstalled() (bool, error) {
+	cmd := exec.Command("brew", "list", "--cask", "--versions", "envault")
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			if len(strings.TrimSpace(string(ee.Stderr))) > 0 {
+				return false, nil
+			}
+		}
+		return false, nil
+	}
+	return strings.TrimSpace(string(out)) != "", nil
+}
+
+func detectInstallSource(path string) string {
+	if strings.Contains(path, "/Caskroom/") {
+		return "homebrew-cask"
+	}
+	if strings.Contains(path, "/Cellar/") || strings.Contains(path, "linuxbrew") {
+		return "homebrew-formula"
+	}
+	if strings.Contains(path, "npm") || strings.Contains(path, "pnpm") || strings.Contains(path, "yarn") || strings.Contains(path, "bun") {
+		return "node-package-manager"
+	}
+	if strings.Contains(path, "/go/bin/") {
+		return "go-install"
+	}
+	if strings.Contains(path, "/usr/local/bin") || strings.Contains(path, "/usr/bin") || strings.Contains(path, "/opt/") {
+		return "system-binary"
+	}
+	return "unknown"
+}
+
+func isHomebrewPath(path string) bool {
+	return strings.Contains(path, "brew") || strings.Contains(path, "Cellar") || strings.Contains(path, "linuxbrew") || strings.Contains(path, "Caskroom")
+}
+
+func normalizeVersion(v string) string {
+	return strings.TrimPrefix(strings.TrimSpace(v), "v")
+}
+
+func init() {
+	rootCmd.AddCommand(doctorCmd)
+}

--- a/cli-go/cmd/doctor_test.go
+++ b/cli-go/cmd/doctor_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import "testing"
+
+func TestDetectInstallSource(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "brew formula",
+			path: "/opt/homebrew/Cellar/envault/1.26.1/bin/envault",
+			want: "homebrew-formula",
+		},
+		{
+			name: "brew cask",
+			path: "/opt/homebrew/Caskroom/envault/1.25.0/envault",
+			want: "homebrew-cask",
+		},
+		{
+			name: "node install",
+			path: "/Users/alice/.npm-global/bin/envault",
+			want: "node-package-manager",
+		},
+		{
+			name: "go install",
+			path: "/Users/alice/go/bin/envault",
+			want: "go-install",
+		},
+		{
+			name: "unknown",
+			path: "/tmp/envault",
+			want: "unknown",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectInstallSource(tc.path)
+			if got != tc.want {
+				t.Fatalf("detectInstallSource(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "v1.26.1", want: "1.26.1"},
+		{in: "1.26.1", want: "1.26.1"},
+		{in: " v2.0.0 ", want: "2.0.0"},
+	}
+
+	for _, tc := range tests {
+		got := normalizeVersion(tc.in)
+		if got != tc.want {
+			t.Fatalf("normalizeVersion(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/cli-go/internal/update/update.go
+++ b/cli-go/internal/update/update.go
@@ -194,8 +194,11 @@ func getUpdateCommand() string {
 	if strings.Contains(path, "bun") {
 		return "bun add -g @dinanathdash/envault"
 	}
+	if strings.Contains(path, "Caskroom") {
+		return "brew uninstall --cask dinanathdash/envault/envault && brew install --formula envault"
+	}
 	if strings.Contains(path, "brew") || strings.Contains(path, "Cellar") || strings.Contains(path, "linuxbrew") {
-		return "brew upgrade envault"
+		return "brew upgrade --formula envault"
 	}
 	if strings.Contains(path, "/go/bin/") || strings.Contains(path, "GOPATH") {
 		return "go install github.com/DinanathDash/Envault/cli-go@latest"

--- a/content/docs/cli/reference.mdx
+++ b/content/docs/cli/reference.mdx
@@ -26,7 +26,29 @@ If you use Homebrew, you can install Envault via our official tap.
 
 ```bash
 brew tap DinanathDash/envault
-brew install envault
+brew install --formula envault
+```
+
+Homebrew cask installs are deprecated. If you installed Envault via cask, migrate to formula:
+
+```bash
+brew uninstall --cask dinanathdash/envault/envault
+brew install --formula envault
+```
+
+If Homebrew shows an older formula version than the latest release, refresh tap metadata:
+
+```bash
+brew update
+brew untap dinanathdash/envault || true
+brew tap dinanathdash/envault
+brew upgrade --formula envault
+```
+
+You can also run diagnostics with:
+
+```bash
+envault doctor
 ```
 
 ### JS Package Managers
@@ -130,6 +152,7 @@ Then run commands without repeating `--file`.
 - `envault deploy` or `envault push`: push local secrets to remote
 - `envault run -- <cmd>`: run a command with injected secrets
 - `envault env map|unmap|default`: manage local file mappings/default env
+- `envault doctor`: diagnose installation and update issues
 - `envault version` or `envault --version`: print version
 - `envault completion <shell>`: generate shell completion
 

--- a/content/docs/guides/ci-cd-integration.mdx
+++ b/content/docs/guides/ci-cd-integration.mdx
@@ -46,7 +46,7 @@ For additional enforcement in pull request checks or deployment gates, use `enva
 steps:
   - uses: actions/checkout@v3
   - name: Install Envault CLI
-    run: curl -sL https://envault.app/install.sh | bash
+    run: curl -fsSL https://raw.githubusercontent.com/DinanathDash/Envault/main/install.sh | sh
   - name: Audit env files
     run: envault audit --strict --format=json
 ```
@@ -76,7 +76,7 @@ jobs:
           node-version: 18
           
       - name: Install Envault CLI
-        run: curl -sL https://envault.app/install.sh | bash
+        run: curl -fsSL https://raw.githubusercontent.com/DinanathDash/Envault/main/install.sh | sh
 
       - name: Install Dependencies
         run: npm ci
@@ -97,7 +97,7 @@ build_app:
   variables:
     ENVAULT_TOKEN: $ENVAULT_SERVICE_TOKEN
   before_script:
-    - curl -sL https://envault.app/install.sh | bash
+    - curl -fsSL https://raw.githubusercontent.com/DinanathDash/Envault/main/install.sh | sh
   script:
     - npm ci
     - envault run --project proj_123 --env production -- npm run build
@@ -111,7 +111,7 @@ You can use Envault to inject secrets at container runtime.
 FROM node:18-alpine
 
 # Install Envault
-RUN curl -sL https://envault.app/install.sh | bash
+RUN curl -fsSL https://raw.githubusercontent.com/DinanathDash/Envault/main/install.sh | sh
 
 WORKDIR /app
 COPY . .

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -165,7 +165,7 @@ export async function GET(request: Request) {
                 style={{ display: "flex", alignItems: "center", gap: "12px" }}
               >
                 <ChevronRight color="#22C55E" />
-                <span>npm install -g envault-cli</span>
+                <span>npm install -g @dinanathdash/envault</span>
               </div>
               <div
                 style={{

--- a/src/components/landing/sections/Hero.tsx
+++ b/src/components/landing/sections/Hero.tsx
@@ -64,8 +64,8 @@ export function Hero() {
 
               <TabsContent value="brew" className="mt-0">
                 <InstallTerminal
-                  command="brew tap DinanathDash/envault && brew install envault"
-                  label="Homebrew"
+                  command="brew tap DinanathDash/envault && brew install --formula envault"
+                  label="Homebrew (Formula)"
                 />
               </TabsContent>
 


### PR DESCRIPTION
This pull request implements a full transition of the Envault CLI to Homebrew formula-only distribution, deprecating the Homebrew cask, and introduces a new `envault doctor` command to help users diagnose installation and upgrade issues. It updates documentation, installation scripts, and CI/CD examples to reflect these changes, and enforces formula-only releases in the build pipeline.

**Key changes:**

**Homebrew formula-only migration:**
- Removed all Homebrew cask configuration from `.goreleaser.yaml` and enforced formula-only release by adding a validation step in the GitHub Actions workflow. The workflow now fails if cask-related configuration is detected.
- Updated all documentation (`README.md`, CLI reference, guides, and install instructions) to use `brew install --formula envault` and provided migration steps for users who previously installed via cask, including troubleshooting for outdated formula metadata.

**New diagnostics command:**
- Added a new `envault doctor` command to the CLI, which detects install source, checks for deprecated cask installs, Homebrew version mismatches, and suggests fixes. Includes supporting test coverage for install source and version normalization logic.
- Mentioned the new `doctor` command in CLI documentation for user visibility.

**Upgrade and install experience improvements:**
- Changed CLI upgrade instructions and logic to use `brew upgrade --formula envault`, and for cask installs, to explicitly uninstall cask and reinstall as formula. 
- Updated CI/CD and Docker integration guides to use the new installation script URL and method.

**Other updates:**
- Updated the npm install command in the Open Graph API route to use the new package name `@dinanathdash/envault`.
- Updated the Homebrew install tab on the landing page to clarify formula-only installation.

---
Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>