### PR TITLE
Refactor font handling and add new font variables in layout

### DIFF
--- a/components.json
+++ b/components.json
@@ -20,6 +20,7 @@
   },
   "registries": {
     "@magicui": "https://magicui.design/r/{name}.json",
-    "@creative-tim": "https://www.creative-tim.com/ui/r/{name}.json"
+    "@creative-tim": "https://www.creative-tim.com/ui/r/{name}.json",
+    "@fonttrio": "https://www.fonttrio.xyz/r/{name}.json"
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,7 +56,7 @@
   body,
   :root,
   * {
-    font-family: "Google Sans", sans-serif;
+    font-family: var(--font-google-sans), sans-serif;
   }
 
   body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import { ShortcutProvider } from "@/components/providers/shortcut-provider";
 import { HmacProvider } from "@/components/hmac-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { getServerOS } from "@/lib/utils/os";
+import { cn } from "@/lib/utils/utils";
 import { headers } from "next/headers";
 import { SystemStatusBanner } from "@/components/ui/system-status-banner";
 import { GlobalScene } from "@/components/landing/ui/GlobalScene";
@@ -21,6 +22,34 @@ import { RootRefreshHandler } from "@/components/RootRefreshHandler";
 import { FreeTierNotification } from "@/components/free-tier-notification";
 import { HapticProvider } from "@/components/providers/haptics-provider";
 import Script from "next/script";
+import { JetBrains_Mono, Instrument_Serif, Google_Sans } from "next/font/google";
+
+const googleSans = Google_Sans({
+  subsets: ["latin", "latin-ext"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
+  preload: true,
+  fallback: ["system-ui", "Segoe UI", "Roboto", "Helvetica", "Arial", "sans-serif"],
+  variable: "--font-google-sans",
+});
+
+const instrumentSerif = Instrument_Serif({
+  subsets: ["latin", "latin-ext"],
+  weight: ["400"],
+  display: "swap",
+  preload: false,
+  fallback: ["Georgia", "Times New Roman", "Times", "serif"],
+  variable: "--font-instrument-serif",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin", "latin-ext"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
+  preload: false,
+  fallback: ["ui-monospace", "SFMono-Regular", "Menlo", "Monaco", "Consolas", "monospace"],
+  variable: "--font-jetbrains-mono",
+});
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.envault.tech"),
@@ -113,20 +142,12 @@ export default async function RootLayout({
   const showBanner = headersList.get("x-show-status-banner") === "1";
 
   return (
-    <html lang="en" suppressHydrationWarning data-os={os}>
-      <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
-        {/* eslint-disable-next-line @next/next/no-page-custom-font */}
-        <link
-          href="https://fonts.googleapis.com/css2?family=Google+Sans:ital,opsz,wght@0,17..18,400..700;1,17..18,400..700&family=Instrument+Serif:ital,wght@0,400;0,700;1,400;1,700&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap"
-          rel="stylesheet"
-        />
-      </head>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      data-os={os}
+      className={cn(jetbrainsMono.variable, instrumentSerif.variable, googleSans.variable)}
+    >
       <body className="min-h-screen bg-background font-sans antialiased">
         <SystemStatusBanner show={showBanner} />
         <Script

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -20,9 +20,9 @@ const config = {
         },
         extend: {
             fontFamily: {
-                sans: ['"Google Sans"', "sans-serif"],
-                serif: ['"Instrument Serif"', "serif"],
-                mono: ['"JetBrains Mono"', "monospace"],
+                sans: ["var(--font-google-sans)", "sans-serif"],
+                serif: ["var(--font-instrument-serif)", "serif"],
+                mono: ["var(--font-jetbrains-mono)", "monospace"],
             },
             colors: {
                 bone: "#F2F2F0",


### PR DESCRIPTION
This pull request updates how custom fonts are loaded and referenced throughout the app, switching from external Google Fonts links to using Next.js's built-in font optimization. It also updates the font-family definitions in global CSS and Tailwind configuration to use CSS variables, and adds a new registry for Fonttrio in the components registry.

Font loading and usage improvements:

* Replaces external Google Fonts `<link>` tags in `src/app/layout.tsx` with Next.js font imports (`JetBrains_Mono`, `Instrument_Serif`, `Google_Sans`), defines them as CSS variables, and applies these variables to the `<html>` element. 
* Updates global font-family in `src/app/globals.css` to use the new `--font-google-sans` CSS variable.
* Updates Tailwind `fontFamily` configuration in `tailwind.config.mjs` to use the new CSS variables for `sans`, `serif`, and `mono` font families.

Component registry update:

* Adds the `@fonttrio` registry to `components.json` for component sourcing.

---
Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>