### PR TITLE
Update email logo URLs to use EMAIL_PUBLIC_APP_URL

### DIFF
--- a/src/lib/infra/email-html.ts
+++ b/src/lib/infra/email-html.ts
@@ -15,7 +15,9 @@ interface EmailProps {
 
 // Logo URLs - Light and Dark PNG variants
 const DEFAULT_APP_URL = (
-  process.env.NEXT_PUBLIC_APP_URL || "https://www.envault.tech"
+  process.env.EMAIL_PUBLIC_APP_URL ||
+  process.env.NEXT_PUBLIC_APP_URL ||
+  "https://www.envault.tech"
 ).replace(/\/+$/, "");
 const DEFAULT_LOGO_LIGHT_URL = `${DEFAULT_APP_URL}/email-logo-light.png`;
 const DEFAULT_LOGO_DARK_URL = `${DEFAULT_APP_URL}/email-logo-dark.png`;

--- a/src/lib/infra/email.ts
+++ b/src/lib/infra/email.ts
@@ -19,10 +19,11 @@ const SENDERS = {
   system: `Envault System <system@${SENDER_DOMAIN}>`,
   digest: `Envault Digest <digest@${SENDER_DOMAIN}>`,
 };
-const APP_URL = (process.env.NEXT_PUBLIC_APP_URL || "https://www.envault.tech").replace(
-  /\/+$/,
-  "",
-);
+const APP_URL = (
+  process.env.EMAIL_PUBLIC_APP_URL ||
+  process.env.NEXT_PUBLIC_APP_URL ||
+  "https://www.envault.tech"
+).replace(/\/+$/, "");
 const LOGO_URL = `${APP_URL}/email-logo-light.png`;
 
 function isValidTimezone(timezone: string): boolean {


### PR DESCRIPTION
This pull request updates how the application determines the base URL for email-related assets. The main improvement is to prioritize the use of a new environment variable, `EMAIL_PUBLIC_APP_URL`, for building URLs in email templates and sending logic. This allows for more flexible configuration of URLs used in emails, separate from those used in the main app.

Configuration improvements for email URLs:

* Updated both `src/lib/infra/email-html.ts` and `src/lib/infra/email.ts` to use `EMAIL_PUBLIC_APP_URL` as the primary source for the base app URL, falling back to `NEXT_PUBLIC_APP_URL` and then the default if not set. 

---
Co-authored-by: Dinanath Dash <108653031+DinanathDash@users.noreply.github.com>