### PR TITLE
Add GitHub Actions workflow for MCP Registry publishing

### DIFF
--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -1,0 +1,67 @@
+name: Publish to MCP Registry
+
+on:
+  workflow_run:
+    workflows:
+      - Publish MCP Server
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # CRITICAL: Required for GitHub OIDC authentication with the registry
+
+concurrency:
+  group: release-registry
+  cancel-in-progress: false
+
+jobs:
+  publish-registry:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    name: Publish to Official Registry
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Fetch Latest npm Version
+        id: get_version
+        shell: bash
+        run: |
+          set -euo pipefail
+          PKG="@dinanathdash/envault-mcp-server"
+          
+          # Fetch the absolute latest version from the npm registry
+          VERSION=$(npm view "$PKG" version)
+          echo "Latest version on npm is $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install mcp-publisher CLI
+        shell: bash
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+
+      - name: Sync Version and Publish via OIDC
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.get_version.outputs.version }}"
+          
+          # Dynamically inject the new version into both required places in server.json
+          jq ".version = \"$VERSION\" | .packages[0].version = \"$VERSION\"" server.json > server-tmp.json
+          mv server-tmp.json server.json
+          
+          # The publisher automatically detects the GitHub Actions OIDC environment
+          # Because of id-token: write, this requires zero passwords/secrets.
+          mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.DinanathDash/envault",
+  "description": "Secure secret management with a Human-In-The-Loop (HITL) interceptor for agent mutations.",
+  "repository": {
+    "url": "https://github.com/DinanathDash/Envault",
+    "source": "github"
+  },
+  "version": "1.11.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@dinanathdash/envault-mcp-server",
+      "version": "1.11.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "ENVAULT_TOKEN",
+          "description": "Required: Generate via Envault Account Settings -> Security -> MCP Token",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "ENVAULT_BASE_URL",
+          "description": "Required: https://www.envault.tech",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for publishing to the MCP Registry and adds a `server.json` metadata file describing the MCP server package. The main focus is on automating the publication process and ensuring the server metadata is properly defined for registry compatibility.

**CI/CD Automation:**

* Added `.github/workflows/publish-registry.yml` to automate publishing to the MCP Registry, including steps for version synchronization, OIDC authentication, and using the `mcp-publisher` CLI. This workflow triggers on completion of the "Publish MCP Server" workflow or via manual dispatch.

**Package Metadata:**

* Added `server.json` describing the MCP server, including schema reference, package name, description, repository details, version, package identifier, transport type, and required environment variables for secure operation.

> Closes #169 

---
Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>