### PR TITLE
Update documentation for version 1.13.0 including licensing and CLI usage

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -10,6 +10,35 @@ All notable changes to Envault are documented here.
 
 ---
 
+## 1.13.0 - 2026-04-22
+
+> Authors: Dinanath Dash (DinanathDash), Rajat Patra (RawJat)
+
+### Vercel Native Integration and Zero-Knowledge Token Flow
+
+- **Zero-Knowledge Token Delivery:** Implemented token exchange and delivery refinements for Vercel integration with stronger secret-handling boundaries.
+- **CORS Validation Hardening:** Added stricter CORS checks and integration route protections across Vercel status, sync, callback, token, and webhook flows.
+- **Environment Mapping UX:** Improved Vercel project linking and environment mapping behavior in both backend routes and dashboard integration controls.
+
+### MCP Registry, HITL Security, and Operational Reliability
+
+- **Official MCP Registry Publishing:** Added automated MCP Registry publication workflow with `server.json` metadata and GitHub Actions OIDC login flow.
+- **HITL Enforcement for Standalone Mutations:** Routed standalone MCP mutation paths through the HITL SDK pipeline for non-bypassable approval semantics.
+- **MCP Runtime Stability:** Improved MCP module path resolution and release pipeline test signaling; added a macOS-safe HITL verification script for staging checks.
+- **MCP Security Docs Expansion:** Expanded MCP server security and contributor documentation to clarify HITL behavior, auth expectations, and release workflows.
+
+### Licensing and Documentation Alignment
+
+- **License Scope Clarification:** Updated repository license scope and exceptions, explicitly carving out `mcp-server/` and `src/lib/sdk/` paths.
+- **Deployment and CI/CD Guidance:** Refined internal and platform docs for Vercel-native sync, CI runtime wrapper usage, and MCP operational guidance.
+
+### Build and Release Stream Updates
+
+- **Build Script Reliability:** Reverted app build execution path to native `next build` for more predictable Vercel deployment behavior.
+- **SDK/MCP Stream Progression:** Included coordinated SDK and MCP package stream bumps (`sdk-v1.6.0` -> `sdk-v1.7.0`, `mcp-v1.10.0` -> `mcp-v1.12.0`) with matching release automation updates.
+
+---
+
 ## 1.12.0 - 2026-04-20
 
 > Authors: Dinanath Dash (DinanathDash)

--- a/README.md
+++ b/README.md
@@ -343,8 +343,10 @@ npm install -g @dinanathdash/envault-mcp-server@latest
 
 Copyright (c) 2026 Dinanath Dash. All Rights Reserved.
 
-The source code is provided strictly for transparency, security auditing, and education. This is not open-source software.
+The repository root source code is provided strictly for transparency, security auditing, and education. This is not open-source software.
 
-You may inspect and analyze the code for security purposes. You may not execute, compile, run, deploy, copy, modify, fork, redistribute, sublicense, or provide any service using this code without prior explicit written permission.
+You may inspect and analyze the code for security purposes. You may not execute, compile, run, deploy, copy, modify, fork, redistribute, sublicense, or provide any service using proprietary repository code without prior explicit written permission.
+
+License scope exception: `mcp-server/` and `src/lib/sdk/` are distributed under MIT licenses in their respective directories.
 
 See the [LICENSE](LICENSE) file for the complete legal terms.

--- a/content/docs/internal/installation.mdx
+++ b/content/docs/internal/installation.mdx
@@ -7,7 +7,7 @@ import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 import { Callout } from "fumadocs-ui/components/callout";
 
-This internal guide is for authorized contributors. Running or deploying Envault source code requires explicit written permission from the copyright holder under the repository license.
+This internal guide is for authorized contributors. Most repository paths are proprietary and require explicit written permission to run or deploy. The `mcp-server/` and `src/lib/sdk/` directories are MIT-licensed exceptions.
 
 ## Monorepo Components
 
@@ -49,10 +49,26 @@ cd envault
 We recommend using `pnpm` for faster installation, but `npm` or `yarn` work just as well.
 
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
-  <Tab value="npm">```bash npm install ```</Tab>
-  <Tab value="pnpm">```bash pnpm install ```</Tab>
-  <Tab value="yarn">```bash yarn install ```</Tab>
-  <Tab value="bun">```bash bun install ```</Tab>
+  <Tab value="npm">
+    ```bash
+    npm install
+    ```
+  </Tab>
+  <Tab value="pnpm">
+    ```bash
+    pnpm install
+    ```
+  </Tab>
+  <Tab value="yarn">
+    ```bash
+    yarn install
+    ```
+  </Tab>
+  <Tab value="bun">
+    ```bash
+    bun install
+    ```
+  </Tab>
 </Tabs>
 
 If you will work on SDK and MCP packages, also install dependencies in each package folder:

--- a/content/docs/platform/cli/reference.mdx
+++ b/content/docs/platform/cli/reference.mdx
@@ -38,10 +38,26 @@ brew install --formula envault
 If you're working in a Node ecosystem, you can install the CLI globally via our NPM wrapper script:
 
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
-  <Tab value="npm">```bash npm install -g @dinanathdash/envault ```</Tab>
-  <Tab value="pnpm">```bash pnpm add -g @dinanathdash/envault ```</Tab>
-  <Tab value="yarn">```bash yarn global add @dinanathdash/envault ```</Tab>
-  <Tab value="bun">```bash bun add -g @dinanathdash/envault ```</Tab>
+  <Tab value="npm">
+    ```bash
+    npm install -g @dinanathdash/envault
+    ```
+  </Tab>
+  <Tab value="pnpm">
+    ```bash
+    pnpm add -g @dinanathdash/envault
+    ```
+  </Tab>
+  <Tab value="yarn">
+    ```bash
+    yarn global add @dinanathdash/envault
+    ```
+  </Tab>
+  <Tab value="bun">
+    ```bash
+    bun add -g @dinanathdash/envault
+    ```
+  </Tab>
 </Tabs>
 
 ---

--- a/content/docs/platform/index.mdx
+++ b/content/docs/platform/index.mdx
@@ -26,7 +26,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 **Envault** is a secure secret management platform for modern development teams. It simplifies the chaos of managing `.env` files across multiple projects, environments, and team members, ensuring your sensitive data is **always encrypted** and **always synchronized**.
 
-Envault's repository is visible for transparency and security auditing under a proprietary all-rights-reserved license. [Learn more about our licensing.](/licensing)
+Envault's repository is visible for transparency and security auditing under a proprietary all-rights-reserved license, with MIT-licensed exceptions for `mcp-server/` and `src/lib/sdk/`. [Learn more about our licensing.](/licensing)
 
 <Callout title="Why Envault?">
   Traditional secret management often involves insecurely sharing `.env` files

--- a/mcp-server/CONTRIBUTING.md
+++ b/mcp-server/CONTRIBUTING.md
@@ -36,3 +36,5 @@ Notes:
 Release note:
 
 - Package versioning and npm publication are managed by semantic-release workflows.
+- Official MCP Registry publication is automated via `.github/workflows/publish-registry.yml` using GitHub OIDC.
+- Registry metadata is sourced from repository root `server.json`; workflow syncs published npm version into that file payload before publish.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "envault",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "envault",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "dependencies": {
         "@ai-sdk/google": "^3.0.57",
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "envault",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "private": true,
   "scripts": {
     "dev": "node scripts/dev.mjs",

--- a/src/app/(marketing)/licensing/page.tsx
+++ b/src/app/(marketing)/licensing/page.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Licensing",
   description:
-    "Learn how Envault source code may be used under the current proprietary inspection license.",
+    "Learn how Envault source code and package subdirectories are licensed, including repository scope exceptions.",
   openGraph: {
     siteName: "Envault",
     images: ["/open-graph/Licensing.png"],
@@ -26,7 +26,7 @@ export default async function LicensingPage() {
   return (
     <LegalLayout
       title="Licensing"
-      lastUpdated="12 April 2026"
+      lastUpdated="22 April 2026"
       sections={sections}
     >
       <section
@@ -39,10 +39,15 @@ export default async function LicensingPage() {
           <strong>proprietary, all-rights-reserved inspection license</strong>.
         </p>
         <p className="text-muted-foreground leading-relaxed">
-          This is <strong>not open source</strong>. You may inspect the code for
-          transparency and security auditing, but you may not run, modify,
-          redistribute, or deploy it unless you have prior written permission
-          from the copyright holder.
+          Most of this repository is <strong>not open source</strong>. You may
+          inspect the code for transparency and security auditing, but you may
+          not run, modify, redistribute, or deploy proprietary portions unless
+          you have prior written permission from the copyright holder.
+        </p>
+        <p className="text-muted-foreground leading-relaxed mt-4">
+          <strong>Scope exception:</strong> the <code>mcp-server/</code> and{" "}
+          <code>src/lib/sdk/</code> directories are distributed under the MIT
+          License. The repository root LICENSE applies to all other paths.
         </p>
       </section>
 
@@ -95,8 +100,8 @@ export default async function LicensingPage() {
               </h3>
             </div>
             <p className="text-muted-foreground leading-relaxed">
-              You may not execute, compile, run, or deploy the Licensed Work in
-              any environment.
+              You may not execute, compile, run, or deploy proprietary
+              repository components in any environment.
             </p>
           </div>
           <div>
@@ -149,8 +154,8 @@ export default async function LicensingPage() {
               Is Envault open source?
             </h3>
             <p className="text-muted-foreground leading-relaxed">
-              No. Envault is source-visible for inspection and security auditing,
-              but it is not licensed as open-source software.
+              No. Envault is source-visible for inspection and security
+              auditing, but it is not licensed as open-source software.
             </p>
           </div>
 
@@ -159,9 +164,9 @@ export default async function LicensingPage() {
               Can I self-host or run Envault locally?
             </h3>
             <p className="text-muted-foreground leading-relaxed">
-              Not under the default license. Running, compiling, or deploying
-              the code requires prior explicit written permission from the
-              copyright holder.
+              Proprietary parts of the repository require prior explicit written
+              permission. The <code>mcp-server/</code> and{" "}
+              <code>src/lib/sdk/</code> directories are MIT-licensed exceptions.
             </p>
           </div>
 
@@ -170,8 +175,9 @@ export default async function LicensingPage() {
               Can I fork or modify this repository?
             </h3>
             <p className="text-muted-foreground leading-relaxed">
-              Not without written permission. The default license prohibits
-              copying, modification, and derivative works.
+              Proprietary repository sections cannot be forked or modified
+              without written permission. MIT-licensed subdirectories follow
+              their own license terms.
             </p>
           </div>
 

--- a/src/app/(marketing)/privacy/page.tsx
+++ b/src/app/(marketing)/privacy/page.tsx
@@ -142,6 +142,10 @@ export default async function PrivacyPage() {
           Envault&apos;s source code is visible for transparency and security
           auditing under a proprietary all-rights-reserved license. This means:
         </p>
+        <p className="text-muted-foreground mb-4 leading-relaxed">
+          Exception: <code>mcp-server/</code> and <code>src/lib/sdk/</code>
+          are distributed under MIT licenses in their respective directories.
+        </p>
         <ul className="list-disc pl-6 space-y-3 text-muted-foreground mb-4">
           <li className="leading-relaxed">
             You can review our source code for security auditing and
@@ -149,7 +153,7 @@ export default async function PrivacyPage() {
           </li>
           <li className="leading-relaxed">
             You cannot execute, compile, run, deploy, copy, or modify the code
-            without prior written permission.
+            in proprietary repository paths without prior written permission.
           </li>
         </ul>
         <p className="text-muted-foreground leading-relaxed">

--- a/src/app/(marketing)/terms/page.tsx
+++ b/src/app/(marketing)/terms/page.tsx
@@ -121,6 +121,10 @@ export default async function TermsPage() {
           permission, you may only inspect the code for transparency and
           security auditing.
         </p>
+        <p className="text-muted-foreground mb-4 leading-relaxed">
+          Exception: <code>mcp-server/</code> and <code>src/lib/sdk/</code> are
+          distributed under MIT licenses in their respective directories.
+        </p>
         <ul className="list-disc pl-6 space-y-2 text-muted-foreground mb-4 leading-relaxed">
           <li>Read, review, and audit the source code</li>
           <li>Analyze code to identify or verify security issues</li>
@@ -128,7 +132,7 @@ export default async function TermsPage() {
         <p className="text-muted-foreground mb-4 leading-relaxed">
           You <strong>cannot</strong> execute, compile, run, deploy, copy,
           modify, fork, redistribute, sublicense, or use the code to provide a
-          service without written permission.
+          service using proprietary repository paths without written permission.
         </p>
         <p className="text-muted-foreground leading-relaxed">
           For complete terms, see our{" "}
@@ -304,9 +308,9 @@ export default async function TermsPage() {
             overwhelming the service.
           </li>
           <li className="leading-relaxed">
-            Agent-based SDK and MCP mutation workflows are subject to
-            delegated token scope checks, rate limits, and explicit human
-            approval requirements.
+            Agent-based SDK and MCP mutation workflows are subject to delegated
+            token scope checks, rate limits, and explicit human approval
+            requirements.
           </li>
           <li className="leading-relaxed">
             You agree not to use the CLI for automated scraping or unauthorized
@@ -467,9 +471,8 @@ export default async function TermsPage() {
           notice or liability, for any reason whatsoever, including without
           limitation if you breach the Terms. Upon termination, your right to
           use the Service will immediately cease. If you request account
-          deletion through the Service, deletion is scheduled with a 7-day
-          grace period and may be canceled by signing back in during that
-          window.
+          deletion through the Service, deletion is scheduled with a 7-day grace
+          period and may be canceled by signing back in during that window.
         </p>
       </section>
 


### PR DESCRIPTION
This pull request introduces Envault version 1.13.0, featuring a major update to licensing clarity, Vercel integration, MCP Registry automation, and documentation improvements. The most notable changes are the explicit MIT license exceptions for `mcp-server/` and `src/lib/sdk/` directories, new Vercel native integration features, and expanded documentation around security, licensing, and operational workflows.

**Licensing Scope Clarification and Documentation:**

* Explicitly documents that the repository is proprietary, but the `mcp-server/` and `src/lib/sdk/` directories are MIT-licensed exceptions. This is reflected in the main marketing site, privacy, terms, internal docs, and README. 

* Updates the `CHANGELOG.mdx` and `package.json` to version 1.13.0, summarizing the new licensing scope, Vercel integration, MCP registry automation, and documentation changes. 

**Vercel Native Integration and Security Enhancements:**

* Implements zero-knowledge token delivery, stricter CORS validation, and improved environment mapping UX for Vercel integration.

**MCP Registry Automation and Security:**

* Adds automated MCP Registry publishing via GitHub Actions OIDC, with workflow details and metadata sync described in both the changelog and contributing documentation.

* Enforces HITL (Human-In-The-Loop) security for standalone MCP mutations and expands security documentation.

**Build, Release, and Documentation Streamlining:**

* Improves build script reliability and updates SDK/MCP package streams, with matching release automation.

* Refines internal and platform documentation for licensing, deployment, installation, and CLI usage, including improved code block formatting in tabbed UI. 

Overall, this release provides clearer legal boundaries for code usage, improved integration and security workflows, and more robust operational documentation.

---
Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>