### PR TITLE
Add Envault Agent Skill documentation and configuration files

### DIFF
--- a/.agents/skills/envault/SKILL.md
+++ b/.agents/skills/envault/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: envault
+description: Official AI Agent Skill for Envault Secrets Management platform. Enforces strict zero-hardcode rules, Client-Side Encryption, and Human-in-the-Loop (HITL) approval workflows.
+---
+
+# Envault Agent Skill
+
+This skill provides critical instructions for interacting with the Envault Secrets Management platform. Envault uses strict Client-Side Encryption and Human-in-the-Loop (HITL) approvals. As an AI agent, you must strictly adhere to the following rules when working with Envault.
+
+## 1. THE ZERO-HARDCODE RULE (`envault run`)
+
+Envault injects secrets directly into process memory.
+- You must **NEVER** create, modify, or suggest creating `.env` files.
+- When writing scripts or running tests that require environment variables, you must execute them using the runtime wrapper:
+  `envault run --env <environment> -- <command>`
+
+## 2. THE HITL NAVIGATOR (Handling Mutations)
+
+Envault's MCP server uses a delegated token model with active Human-in-the-Loop (HITL) safeguards.
+- When you attempt to mutate a secret (e.g., using `envault_push` or `envault_deploy`), the server intercepts the request and returns a `202 Accepted` response. This response includes an `approval_id` and an `approval_url`.
+- **A `202 Accepted` is NOT a failure.**
+- You must immediately **stop execution**, present the approval link to the user, and wait for the user to approve it via the UI or by typing `envault approve <approval_id>` in the terminal.
+- You must **not** retry the mutation automatically.
+
+## 3. GIT COMPLIANCE
+
+Envault has active safeguards regarding git tracking.
+- If an `envault pull` or `envault deploy` command fails because a file is already tracked in git, you must **not** try to force the operation.
+- Instead, you must:
+  1. Execute `git rm --cached <file>` to untrack the file.
+  2. Ensure the file is added to `.gitignore`.
+  3. Retry the Envault command.

--- a/.agents/skills/envault/metadata.json
+++ b/.agents/skills/envault/metadata.json
@@ -1,0 +1,5 @@
+{
+  "name": "envault",
+  "description": "Official AI Agent Skill for Envault Secrets Management platform. Enforces strict zero-hardcode rules, Client-Side Encryption, and Human-in-the-Loop (HITL) approval workflows.",
+  "author": "Envault"
+}

--- a/content/docs/platform/guides/mcp-agents.mdx
+++ b/content/docs/platform/guides/mcp-agents.mdx
@@ -78,3 +78,13 @@ When an AI attempts a mutation (for example: creating or updating a secret using
 After setup, ask your AI assistant to run a read operation (for example status/context). Then ask for a mutation and confirm you receive the approval link flow.
 
 This validates both delegated auth and HITL controls in your local environment.
+
+## 4. Install the Agent Skill (Cursor / Cline / Windsurf)
+
+To ensure your AI agent understands Envault's HITL approvals and zero-hardcode rules, install the official Envault Agent Skill into your repository.
+
+Run this at the root of your project:
+```bash
+npx skills add https://github.com/DinanathDash/Envault --skill envault
+```
+This pulls the official instructions into your local `.agents/skills` directory, preventing the agent from trying to bypass client-side encryption or getting stuck in retry loops during HITL approvals.


### PR DESCRIPTION
This pull request introduces official documentation and metadata for the Envault Agent Skill, which enforces strict security and operational guidelines for using the Envault Secrets Management platform with AI agents. The changes ensure that agents comply with zero-hardcode rules, handle Human-in-the-Loop (HITL) approval workflows correctly, and maintain git compliance. Additionally, installation instructions for the skill are added to the platform documentation.

**Envault Agent Skill Documentation and Metadata:**

* Added `.agents/skills/envault/SKILL.md` with detailed operational rules for AI agents using Envault, covering zero-hardcode enforcement, HITL approval handling, and git compliance requirements.
* Introduced `.agents/skills/envault/metadata.json` containing the skill's name, description, and author for proper registration and discovery.

**Platform Documentation Update:**

* Updated `content/docs/platform/guides/mcp-agents.mdx` to include installation instructions for the Envault Agent Skill, ensuring that users can easily add the skill to their repositories and benefit from its safeguards.

---
Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>