### PR TITLE
Migrate email provider to Brevo and update documentation

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -14,6 +14,16 @@ All notable changes to Envault are documented here.
 
 > Authors: Dinanath Dash (DinanathDash)
 
+### Infrastructure
+
+- **Email Provider Migration (Resend -> Brevo):** Replaced the `resend` SDK with a native `fetch`-based wrapper using the Brevo SMTP API. Updated all 17 email functions and removed the `resend` package.
+- **Multi-Sender Test Script:** Added `--all` flag to `send-test-email.ts` and a `test:email:all` npm script to test all configured sender domains at once.
+
+### Contact & Branding
+
+- **Unified Contact Email:** Updated all public-facing contact links (legal pages, footer, support modal, `SECURITY.md`, feedback script) to `connect@envault.tech`.
+- **Pre-Filled `mailto:` Templates:** Contact links now open the user's mail client with a context-specific pre-filled subject and body.
+
 ### Features & SEO
 
 - **Marketing Pages & SEO:** Added new features page, comparison routes, and updated SEO sitemap while cleaning up project documentation.
@@ -30,6 +40,8 @@ All notable changes to Envault are documented here.
 
 ### Documentation
 
+- **Brevo Migration Docs:** Updated `configuration.mdx`, `initial-setup.mdx`, `production-deployment.mdx`, and `environment-variables.mdx` to reflect the Resend -> Brevo migration and new `BREVO_API_KEY` variable.
+- **License Scope:** Added a Section 6 to `LICENSE.txt` clarifying that `mcp-server/` and `src/lib/sdk/` are distributed under the MIT License.
 - **Changelog Structure:** Restructured changelog categories for better readability.
 
 ---

--- a/content/docs/internal/configuration.mdx
+++ b/content/docs/internal/configuration.mdx
@@ -50,17 +50,17 @@ Once created, populate your `.env.local` or production environment with the gene
 
 ---
 
-## Setting up Notifications (Resend & Cron)
+## Setting up Notifications (Brevo & Cron)
 
-For authorized private deployments, the platform requires an active **Resend** account to send emails (like invites and security alerts).
+For authorized private deployments, the platform requires an active **Brevo** account to send emails (like invites and security alerts).
 
-### 1. Resend Configuration
+### 1. Brevo Configuration
 
-Sign up at [resend.com](https://resend.com) and generate an API key. Add it to your `.env.local` or production environment:
+Sign up at [brevo.com](https://brevo.com) and generate an API key. Add it to your `.env.local` or production environment:
 
 | Variable         | Description         |
 | :--------------- | :------------------ |
-| `RESEND_API_KEY` | Your Resend API Key |
+| `BREVO_API_KEY` | Your Brevo API Key |
 
 ### 2. Cron Configuration for Digests
 
@@ -75,4 +75,4 @@ Generate a strong random string (e.g. `openssl rand -hex 32`) and set it as:
 Once deployed, set up a cron job (via GitHub Actions, Vercel Cron, or a Linux `crontab`) that calls:
 `GET https://your-domain.com/api/cron/digest`
 using the header: `Authorization: Bearer <CRON_SECRET>`.
-This triggers Envault to process the notification queue and send the formatted emails out via Resend.
+This triggers Envault to process the notification queue and send the formatted emails out via Brevo.

--- a/content/docs/internal/configuration/environment-variables.mdx
+++ b/content/docs/internal/configuration/environment-variables.mdx
@@ -35,7 +35,7 @@ These environment variables are required to run the Envault server (Next.js app)
 
 | Variable         | Description                                                         | Default             |
 | :--------------- | :------------------------------------------------------------------ | :------------------ |
-| `RESEND_API_KEY` | Resend API key for sending application emails.                      | Not set             |
+| `BREVO_API_KEY` | Brevo API key for sending application emails.                      | Not set             |
 | `EMAIL_DOMAIN`   | Sender domain for system emails (`team@...`, `security@...`, etc.). | `mail.envault.tech` |
 | `PORT`           | Runtime port for local/server process startup.                      | Platform default    |
 | `NODE_ENV`       | Runtime mode for framework behavior and development-only fallbacks. | `development`       |

--- a/content/docs/internal/initial-setup.mdx
+++ b/content/docs/internal/initial-setup.mdx
@@ -79,13 +79,13 @@ Open [https://envault.localhost:1355](https://envault.localhost:1355) with your 
 
 ## Email Configuration (Optional)
 
-Envault uses [Resend](https://resend.com) to send emails for invites and notifications.
+Envault uses [Brevo](https://brevo.com) to send emails for invites and notifications.
 
-1. Sign up for a Resend account and create an API Key.
+1. Sign up for a Brevo account and create an API Key.
 2. Add your key to `.env.local`:
 
 ```bash
-RESEND_API_KEY=your_resend_api_key
+BREVO_API_KEY=your_brevo_api_key
 ```
 
 You can verify that your email configuration works by sending a test email:

--- a/content/docs/internal/production-deployment.mdx
+++ b/content/docs/internal/production-deployment.mdx
@@ -29,7 +29,7 @@ Before deploying, ensure you have the following environment variables configured
 | `ENVAULT_GITHUB_APP_PRIVATE_KEY` | RSA private key, single-line `\n`-escaped                                     | For GitHub Integration                     |
 | `ENVAULT_GITHUB_WEBHOOK_SECRET`  | Secret to verify GitHub webhook payloads                                      | For GitHub Integration                     |
 | `NEXT_PUBLIC_GITHUB_APP_NAME`    | Your GitHub App's slug name                                                   | For GitHub Integration                     |
-| `RESEND_API_KEY`                 | Resend key for transactional + digest emails                                  | For email delivery                         |
+| `BREVO_API_KEY`                 | Brevo key for transactional + digest emails                                  | For email delivery                         |
 | `EMAIL_DOMAIN`                   | Sender domain for outgoing emails                                             | Optional (defaults to `mail.envault.tech`) |
 | `VERCEL_CLIENT_ID`               | Vercel OAuth client ID for Envault integration callback exchange              | For Vercel integration                     |
 | `VERCEL_CLIENT_SECRET`           | Vercel OAuth client secret                                                    | For Vercel integration                     |


### PR DESCRIPTION
This pull request documents the migration of Envault's email provider from Resend to Brevo, updates all relevant documentation, and clarifies contact and licensing details. The changes are grouped into infrastructure/email migration, contact & branding, and documentation improvements.

**Infrastructure & Email Migration:**
- Replaced the `resend` SDK with a native `fetch`-based wrapper for the Brevo SMTP API, updating all 17 email functions and removing the `resend` package. Also added a test script to send emails from all configured sender domains.
- Updated all environment variable documentation and setup guides to use `BREVO_API_KEY` instead of `RESEND_API_KEY`. 

**Contact & Branding:**
- Standardized all public-facing contact links to use `connect@envault.tech` and added pre-filled `mailto:` templates for context-specific inquiries.

**Documentation:**
- Updated setup, configuration, and deployment docs to reflect the Brevo migration and new environment variable.
- Added a section to the license clarifying the scope for specific directories.
- Improved changelog structure for readability.

---
Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>