### PR TITLE
Add timeout flag to CLI commands for improved resilience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ cli-go/envault
 cli-go/envault.json
 cli-go/out.txt
 cli-go/.env
+cli-go/.gocache
 
 # Generated source files (fumadocs-mdx)
 .source/

--- a/cli-go/cmd/network_timeout.go
+++ b/cli-go/cmd/network_timeout.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"time"
+)
+
+const defaultCLINetworkTimeout = 5 * time.Minute
+
+func resolveCLINetworkTimeout(flagTimeout time.Duration) time.Duration {
+	if flagTimeout > 0 {
+		return flagTimeout
+	}
+
+	raw := strings.TrimSpace(os.Getenv("ENVAULT_RETRY_MAX_DURATION"))
+	if raw == "" {
+		return defaultCLINetworkTimeout
+	}
+
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return defaultCLINetworkTimeout
+	}
+
+	return d
+}

--- a/cli-go/cmd/pull.go
+++ b/cli-go/cmd/pull.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/DinanathDash/Envault/cli-go/internal/api"
@@ -40,6 +41,7 @@ type ProjectResponse struct {
 var forcePull bool
 var projectFlag string
 var fileFlag string
+var pullTimeoutFlag time.Duration
 
 var pullCmd = &cobra.Command{
 	Use:   "pull",
@@ -47,7 +49,7 @@ var pullCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Graceful cancellation: cancel the context on Ctrl+C / SIGTERM so that
 		// in-flight HTTP requests are aborted cleanly.
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), resolveCLINetworkTimeout(pullTimeoutFlag))
 		defer cancel()
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
@@ -335,4 +337,5 @@ func init() {
 	pullCmd.Flags().BoolVarP(&forcePull, "force", "f", false, "Overwrite .env without confirmation")
 	pullCmd.Flags().StringVarP(&projectFlag, "project", "p", "", "Project ID")
 	pullCmd.Flags().StringVar(&fileFlag, "file", "", "Local .env file path override")
+	pullCmd.Flags().DurationVar(&pullTimeoutFlag, "timeout", 0, "Maximum duration for API retry/wait behavior (e.g. 30s, 2m). Overrides ENVAULT_RETRY_MAX_DURATION.")
 }

--- a/cli-go/cmd/run.go
+++ b/cli-go/cmd/run.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -17,6 +17,8 @@ import (
 	"github.com/DinanathDash/Envault/cli-go/internal/ui"
 	"github.com/spf13/cobra"
 )
+
+var runTimeoutFlag time.Duration
 
 var runCmd = &cobra.Command{
 	Use:   "run -- <command>",
@@ -50,12 +52,14 @@ var runCmd = &cobra.Command{
 		}
 		client := api.NewClient()
 		path := fmt.Sprintf("/projects/%s/secrets?environment=%s", projectID, url.QueryEscape(targetEnv))
+		ctx, cancel := context.WithTimeout(context.Background(), resolveCLINetworkTimeout(runTimeoutFlag))
+		defer cancel()
 
 		var secretsResp SecretsResponse
 		var envSecrets []offlinecache.Secret
 		loader := ui.NewLoader(ui.LoaderThemeFetch, fmt.Sprintf("VaultPulse preparing runtime secrets (%s)...", targetEnv))
 		loader.Start()
-		respBytes, err := client.GetWithTimeout(path, resolveRunTimeout(client.BaseURL))
+		respBytes, err := client.GetWithContext(ctx, path)
 		loader.Stop()
 
 		usedOfflineCache := false
@@ -165,25 +169,6 @@ func humanizeDuration(d time.Duration) string {
 	return d.Round(time.Minute).String()
 }
 
-func resolveRunTimeout(baseURL string) time.Duration {
-	defaultSeconds := 10
-	if isLocalBaseURL(baseURL) {
-		defaultSeconds = 20
-	}
-
-	raw := strings.TrimSpace(os.Getenv("ENVAULT_RUN_TIMEOUT_SECONDS"))
-	if raw == "" {
-		return time.Duration(defaultSeconds) * time.Second
-	}
-
-	seconds, err := strconv.Atoi(raw)
-	if err != nil || seconds <= 0 {
-		return time.Duration(defaultSeconds) * time.Second
-	}
-
-	return time.Duration(seconds) * time.Second
-}
-
 func isLocalBaseURL(baseURL string) bool {
 	u, err := url.Parse(baseURL)
 	if err != nil {
@@ -221,4 +206,5 @@ func isLikelyDevCommand(runTarget string, runArgs []string) bool {
 func init() {
 	rootCmd.AddCommand(runCmd)
 	runCmd.Flags().StringVarP(&projectFlag, "project", "p", "", "Project ID")
+	runCmd.Flags().DurationVar(&runTimeoutFlag, "timeout", 0, "Maximum duration for API retry/wait behavior (e.g. 30s, 2m). Overrides ENVAULT_RETRY_MAX_DURATION.")
 }

--- a/cli-go/internal/api/client.go
+++ b/cli-go/internal/api/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -33,6 +34,15 @@ type Client struct {
 	Token   string
 	HTTP    *http.Client
 }
+
+var (
+	defaultRetryMaxDuration = 5 * time.Minute
+	retryBaseBackoff        = 2 * time.Second
+	retryMultiplier         = 2.0
+	sleepWithContextFn      = sleepWithContext
+	refreshTokenFn          = func(c *Client, httpClient *http.Client) error { return c.refreshToken(httpClient) }
+	nowFn                   = time.Now
+)
 
 func NewClient() *Client {
 	baseURL := os.Getenv("ENVAULT_CLI_URL")
@@ -189,62 +199,187 @@ func (c *Client) doReqCtx(ctx context.Context, method, path string, body interfa
 		httpClient = &http.Client{}
 	}
 
-	var bodyReader io.Reader
-
+	var reqBody []byte
+	var err error
 	if body != nil {
-		reqBody, err := json.Marshal(body)
+		reqBody, err = json.Marshal(body)
 		if err != nil {
 			return nil, err
 		}
-		bodyReader = bytes.NewBuffer(reqBody)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, bodyReader)
-	if err != nil {
-		return nil, err
-	}
+	start := nowFn()
+	attempt := 1
+	tokenRefreshTried := false
+	maxDuration := resolveRetryMaxDuration()
 
-	req.Header.Set("Content-Type", "application/json")
-	if c.Token != "" {
-		req.Header.Set("Authorization", "Bearer "+c.Token)
-	}
-	if actorSource := strings.TrimSpace(os.Getenv("ENVAULT_CLI_ACTOR_SOURCE")); actorSource != "" {
-		req.Header.Set("X-Envault-Actor-Source", actorSource)
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == 401 && canRetry {
-		if c.Token != "" && !strings.HasPrefix(c.Token, "envault_svc_") {
-			bodyBytes, _ := io.ReadAll(resp.Body)
-			errRefresh := c.refreshToken(httpClient)
-			if errRefresh == nil {
-				return c.doReqCtx(ctx, method, path, body, false, httpClient)
-			}
-			return nil, fmt.Errorf("Refresh Token Exchange Failed: %v | (Original Auth Error: %s)", errRefresh, string(bodyBytes))
+	for {
+		var bodyReader io.Reader
+		if reqBody != nil {
+			bodyReader = bytes.NewReader(reqBody)
 		}
-	}
 
-	if resp.StatusCode >= 400 {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		bodyStr := string(bodyBytes)
+		req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, bodyReader)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+		if c.Token != "" {
+			req.Header.Set("Authorization", "Bearer "+c.Token)
+		}
+		if actorSource := strings.TrimSpace(os.Getenv("ENVAULT_CLI_ACTOR_SOURCE")); actorSource != "" {
+			req.Header.Set("X-Envault-Actor-Source", actorSource)
+		}
+
+		resp, reqErr := httpClient.Do(req)
+		if reqErr != nil {
+			if !canRetry || !isRetryableRequestError(reqErr) {
+				return nil, reqErr
+			}
+			wait, ok := computeRetryWait(start, attempt, maxDuration)
+			if !ok {
+				return nil, reqErr
+			}
+			logRetryWarning(method, path, attempt, reqErr, wait)
+			if err := sleepWithContextFn(ctx, wait); err != nil {
+				return nil, err
+			}
+			attempt++
+			continue
+		}
+
+		bodyBytes, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+
+		if resp.StatusCode == 401 && canRetry && !tokenRefreshTried {
+			if c.Token != "" && !strings.HasPrefix(c.Token, "envault_svc_") {
+				errRefresh := refreshTokenFn(c, httpClient)
+				if errRefresh == nil {
+					tokenRefreshTried = true
+					continue
+				}
+				return nil, fmt.Errorf("Refresh Token Exchange Failed: %v | (Original Auth Error: %s)", errRefresh, string(bodyBytes))
+			}
+		}
+
+		if isRetryableStatusCode(resp.StatusCode) && canRetry {
+			wait, ok := computeRetryWait(start, attempt, maxDuration)
+			if !ok {
+				return nil, &APIError{StatusCode: resp.StatusCode, Body: string(bodyBytes)}
+			}
+			logRetryWarning(method, path, attempt, fmt.Errorf("server returned %s", resp.Status), wait)
+			if err := sleepWithContextFn(ctx, wait); err != nil {
+				return nil, err
+			}
+			attempt++
+			continue
+		}
+
+		if resp.StatusCode >= 400 {
+			bodyStr := string(bodyBytes)
+			contentType := resp.Header.Get("Content-Type")
+			if strings.Contains(contentType, "text/html") {
+				bodyStr = "Server returned an HTML page (" + resp.Status + "). Ensure the API server is running."
+			}
+			return nil, &APIError{StatusCode: resp.StatusCode, Body: bodyStr}
+		}
+
 		contentType := resp.Header.Get("Content-Type")
 		if strings.Contains(contentType, "text/html") {
-			bodyStr = "Server returned an HTML page (" + resp.Status + "). Ensure the API server is running."
+			return nil, &APIError{StatusCode: resp.StatusCode, Body: "Server returned HTML instead of expected JSON API response. Ensure the API server is running."}
 		}
-		return nil, &APIError{StatusCode: resp.StatusCode, Body: bodyStr}
+
+		return bodyBytes, nil
+	}
+}
+
+func isRetryableStatusCode(statusCode int) bool {
+	return statusCode >= 500 && statusCode <= 599
+}
+
+func isRetryableRequestError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	return IsFallbackEligible(err)
+}
+
+func computeRetryWait(start time.Time, attempt int, maxDuration time.Duration) (time.Duration, bool) {
+	if attempt < 1 {
+		attempt = 1
+	}
+	exp := retryBaseBackoff
+	for i := 1; i < attempt; i++ {
+		next := time.Duration(float64(exp) * retryMultiplier)
+		if next <= exp {
+			break
+		}
+		exp = next
+	}
+	wait := jitterDuration(exp)
+	if wait <= 0 {
+		wait = retryBaseBackoff
 	}
 
-	contentType := resp.Header.Get("Content-Type")
-	if strings.Contains(contentType, "text/html") {
-		return nil, &APIError{StatusCode: resp.StatusCode, Body: "Server returned HTML instead of expected JSON API response. Ensure the API server is running."}
+	elapsed := nowFn().Sub(start)
+	if elapsed >= maxDuration {
+		return 0, false
+	}
+	if elapsed+wait > maxDuration {
+		remaining := maxDuration - elapsed
+		if remaining > time.Second {
+			wait = remaining
+			return wait, true
+		}
+		return 0, false
+	}
+	return wait, true
+}
+
+func resolveRetryMaxDuration() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("ENVAULT_RETRY_MAX_DURATION"))
+	if raw == "" {
+		return defaultRetryMaxDuration
 	}
 
-	return io.ReadAll(resp.Body)
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return defaultRetryMaxDuration
+	}
+
+	return d
+}
+
+func jitterDuration(base time.Duration) time.Duration {
+	// Full-jitter style randomization in [base/2, base) to spread retries.
+	half := base / 2
+	if half <= 0 {
+		return base
+	}
+	return half + time.Duration(rand.Int63n(int64(half)))
+}
+
+func logRetryWarning(method, path string, attempt int, cause error, wait time.Duration) {
+	fmt.Fprintf(os.Stderr, "Warning: Envault API transient failure (%s %s, attempt %d). Retrying in %s. Cause: %v\n",
+		method, path, attempt, wait.Round(time.Millisecond), cause)
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func IsFallbackEligible(err error) bool {

--- a/cli-go/internal/api/client_test.go
+++ b/cli-go/internal/api/client_test.go
@@ -3,10 +3,14 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -54,6 +58,20 @@ func TestIsFallbackEligible(t *testing.T) {
 }
 
 func TestGetWithTimeout(t *testing.T) {
+	origSleep := sleepWithContextFn
+	origNow := nowFn
+	current := time.Now()
+	nowFn = func() time.Time { return current }
+	sleepWithContextFn = func(ctx context.Context, d time.Duration) error {
+		current = current.Add(d)
+		return nil
+	}
+	t.Setenv("ENVAULT_RETRY_MAX_DURATION", "50ms")
+	defer func() {
+		sleepWithContextFn = origSleep
+		nowFn = origNow
+	}()
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(200 * time.Millisecond)
 		w.WriteHeader(http.StatusOK)
@@ -94,6 +112,20 @@ func TestGetWithContext_CancelledContext(t *testing.T) {
 }
 
 func TestGetWithContextAndTimeout_TimesOut(t *testing.T) {
+	origSleep := sleepWithContextFn
+	origNow := nowFn
+	current := time.Now()
+	nowFn = func() time.Time { return current }
+	sleepWithContextFn = func(ctx context.Context, d time.Duration) error {
+		current = current.Add(d)
+		return nil
+	}
+	t.Setenv("ENVAULT_RETRY_MAX_DURATION", "50ms")
+	defer func() {
+		sleepWithContextFn = origSleep
+		nowFn = origNow
+	}()
+
 	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(200 * time.Millisecond)
 		w.WriteHeader(http.StatusOK)
@@ -157,5 +189,211 @@ func TestGetWithContext_SuccessfulRequest(t *testing.T) {
 	}
 	if string(body) != `{"ok":true}` {
 		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestGetWithContext_RetriesOn5xxThenSucceeds(t *testing.T) {
+	origSleep := sleepWithContextFn
+	sleepWithContextFn = func(ctx context.Context, d time.Duration) error { return nil }
+	defer func() { sleepWithContextFn = origSleep }()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"temporary outage"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	client := &Client{BaseURL: srv.URL, HTTP: &http.Client{}}
+	body, err := client.GetWithContext(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("expected success after retries, got error: %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("unexpected body: %s", string(body))
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("expected 3 attempts (2 retries), got %d", got)
+	}
+}
+
+func TestGetWithContext_DoesNotRetryOn4xx(t *testing.T) {
+	origSleep := sleepWithContextFn
+	sleepWithContextFn = func(ctx context.Context, d time.Duration) error {
+		t.Fatalf("sleep/retry should not be called for 4xx")
+		return nil
+	}
+	defer func() { sleepWithContextFn = origSleep }()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	client := &Client{BaseURL: srv.URL, Token: "envault_svc_test", HTTP: &http.Client{}}
+	_, err := client.GetWithContext(context.Background(), "/")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected 1 attempt for 4xx response, got %d", got)
+	}
+}
+
+type flakyRoundTripper struct {
+	remainingFailures int32
+}
+
+func (f *flakyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if atomic.AddInt32(&f.remainingFailures, -1) >= 0 {
+		return nil, &url.Error{
+			Op:  req.Method,
+			URL: req.URL.String(),
+			Err: &net.OpError{Op: "dial", Net: "tcp", Err: fmt.Errorf("connection reset by peer")},
+		}
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func TestGet_RetriesTransientNetworkError(t *testing.T) {
+	origSleep := sleepWithContextFn
+	sleepWithContextFn = func(ctx context.Context, d time.Duration) error { return nil }
+	defer func() { sleepWithContextFn = origSleep }()
+
+	rt := &flakyRoundTripper{remainingFailures: 1}
+	client := &Client{
+		BaseURL: "https://example.com",
+		HTTP:    &http.Client{Transport: rt},
+	}
+
+	body, err := client.Get("/")
+	if err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("unexpected body: %s", string(body))
+	}
+}
+
+func TestDoReqCtx_401Then503(t *testing.T) {
+	origSleep := sleepWithContextFn
+	origRefresh := refreshTokenFn
+	sleepCalls := 0
+	sleepWithContextFn = func(ctx context.Context, d time.Duration) error {
+		sleepCalls++
+		return nil
+	}
+	refreshTokenFn = func(c *Client, httpClient *http.Client) error {
+		c.Token = "refreshed-token"
+		return nil
+	}
+	defer func() {
+		sleepWithContextFn = origSleep
+		refreshTokenFn = origRefresh
+	}()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		switch n {
+		case 1:
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"expired"}`))
+		case 2, 3:
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"temporary"}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}
+	}))
+	defer srv.Close()
+
+	client := &Client{BaseURL: srv.URL, Token: "oauth_token", HTTP: &http.Client{}}
+	body, err := client.GetWithContext(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("unexpected body: %s", body)
+	}
+	if got := atomic.LoadInt32(&calls); got != 4 {
+		t.Fatalf("expected 4 attempts, got %d", got)
+	}
+	if sleepCalls != 2 {
+		t.Fatalf("expected 2 backoff waits for 503 responses, got %d", sleepCalls)
+	}
+}
+
+func TestComputeRetryWait_FinalAttemptOptimization(t *testing.T) {
+	origBase := retryBaseBackoff
+	defer func() { retryBaseBackoff = origBase }()
+	retryBaseBackoff = 30 * time.Second
+
+	start := time.Now().Add(-(4*time.Minute + 50*time.Second))
+	wait, ok := computeRetryWait(start, 1, 5*time.Minute)
+	if !ok {
+		t.Fatal("expected final clipped retry attempt to be allowed")
+	}
+	if wait <= 9*time.Second || wait > 10*time.Second {
+		t.Fatalf("expected wait clipped to remaining time (~10s), got %s", wait)
+	}
+}
+
+func TestConfigurableTimeoutEnvVar(t *testing.T) {
+	origSleep := sleepWithContextFn
+	origNow := nowFn
+	origBase := retryBaseBackoff
+	origMul := retryMultiplier
+	t.Setenv("ENVAULT_RETRY_MAX_DURATION", "5s")
+
+	current := time.Now()
+	nowFn = func() time.Time { return current }
+	sleepWithContextFn = func(ctx context.Context, d time.Duration) error {
+		current = current.Add(d)
+		return nil
+	}
+	retryBaseBackoff = 2 * time.Second
+	retryMultiplier = 2.0
+	defer func() {
+		sleepWithContextFn = origSleep
+		nowFn = origNow
+		retryBaseBackoff = origBase
+		retryMultiplier = origMul
+	}()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error":"bad gateway"}`))
+	}))
+	defer srv.Close()
+
+	client := &Client{BaseURL: srv.URL, HTTP: &http.Client{}}
+	_, err := client.GetWithContext(context.Background(), "/")
+	if err == nil {
+		t.Fatal("expected error after retry max duration")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected 502 APIError, got %v", err)
+	}
+	if atomic.LoadInt32(&calls) < 2 {
+		t.Fatalf("expected retries before giving up, got %d calls", calls)
 	}
 }

--- a/content/docs/platform/cli/commands.mdx
+++ b/content/docs/platform/cli/commands.mdx
@@ -59,6 +59,7 @@ Flags:
 - `-p, --project <id>`: Target a specific project UUID instead of the linked one
 - `--file <path>`: Override the output file path (e.g., `--file .env.custom`)
 - `-f, --force`: Skip overwrite confirmations
+- `--timeout <duration>`: Set the maximum duration the CLI will wait and retry if the Envault API experiences transient network issues (e.g., `30s`, `5m`). Defaults to `5m`.
 
 ### Automatic Safety Guards
 
@@ -144,6 +145,10 @@ envault run --env preview -- npm run dev
 
 The `run` command fetches secrets and dynamically pipes them into the specified process's environment variables.
 This is the most secure method of utilizing secrets locally, as plaintext variables never touch your hard drive.
+
+Flags:
+
+- `--timeout <duration>`: Set the maximum duration the CLI will wait and retry if the Envault API experiences transient network issues (e.g., `30s`, `5m`). Defaults to `5m`.
 
 ---
 

--- a/content/docs/platform/guides/ci-cd.mdx
+++ b/content/docs/platform/guides/ci-cd.mdx
@@ -125,3 +125,16 @@ npx @dinanathdash/envault run --env development -- npm run dev
 ```
 
 Use Service Tokens only for non-human automation contexts (CI/CD, bots, deploy systems).
+
+## Network Resilience and Timeouts
+
+By default, the Envault CLI is highly resilient to transient network drops. If the Envault API is temporarily unreachable during a CI/CD run, `envault run` will automatically retry with exponential backoff for up to **5 minutes**.
+
+If you have strict CI/CD billing constraints and prefer your pipeline to fail faster during an outage, override this behavior using the `--timeout` flag or the environment variable:
+
+```bash
+# Fail fast after 30 seconds
+envault run --env production --timeout 30s -- npm run build
+```
+
+Alternatively, set `ENVAULT_RETRY_MAX_DURATION=30s` in your pipeline secrets.

--- a/src/lib/sdk/cli-tool-definition.generated.json
+++ b/src/lib/sdk/cli-tool-definition.generated.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-21T18:19:02.032Z",
+  "generatedAt": "2026-05-03T19:20:41.815Z",
   "sourceDir": "cli-go/cmd",
   "commands": [
     {


### PR DESCRIPTION
This pull request implements robust, configurable network retry logic for the Envault CLI, improving resilience to transient API/network failures. It introduces a unified `--timeout` flag (and `ENVAULT_RETRY_MAX_DURATION` env var) for `pull` and `run` commands, which controls the maximum duration for retrying failed API requests. The retry logic uses exponential backoff with jitter and is thoroughly tested for various scenarios.

**Network Resilience & Retry Logic:**

* Adds exponential backoff with jitter for retrying transient network and server (5xx) errors in the API client, up to a configurable maximum duration (`ENVAULT_RETRY_MAX_DURATION`, default 5 minutes). 
* Refactors API client to respect context cancellation and to avoid retrying on 4xx errors (except for 401, which triggers a token refresh). 
**CLI Command Improvements:**

* Adds a `--timeout` flag to both `pull` and `run` commands, allowing users to override the maximum retry duration from the command line. 
* Both commands now use a unified timeout resolver, defaulting to 5 minutes if not set by flag or env var. 

**Testing & Documentation:**

* Adds comprehensive tests for retry logic, including network errors, 5xx/4xx handling, token refresh, and timeout configuration. 
* Updates CLI documentation for `pull` and `run` commands, and adds a new section on network resilience and timeouts. 

---
Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>