### PR TITLE
Realign core value proposition for developer onboarding and secret management

### DIFF
--- a/content/docs/platform/index.mdx
+++ b/content/docs/platform/index.mdx
@@ -1,17 +1,12 @@
 ---
 title: Introduction
-description: Secure, collaborative, and developer-friendly environment variable management.
+description: Onboard developers to project secrets in seconds with `envault login` and `envault pull`.
 icon: Rocket
 ---
 
 import {
-  NotebookPen,
   Terminal,
   Shield,
-  Server,
-  Network,
-  Lock,
-  Users,
   Database,
   ServerCrash,
   Palette,
@@ -24,16 +19,43 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 ## Welcome to Envault
 
-**Envault** is a secure secret management platform for modern development teams. It simplifies the chaos of managing `.env` files across multiple projects, environments, and team members, ensuring your sensitive data is **always encrypted** and **always synchronized**.
+**Envault** is a developer onboarding tool for project secrets. It replaces manual `.env` sharing with a fast terminal flow: run `envault login`, run `envault pull`, and start coding.
+
+For teams using GitHub, Envault's Just-in-Time (JIT) integration checks repository collaborators during `envault pull` and grants Viewer access automatically when eligible. That means no manual invite loop for every new teammate.
 
 Envault's repository is visible for transparency and security auditing under a proprietary all-rights-reserved license, with MIT-licensed exceptions for `mcp-server/` and `src/lib/sdk/`. [Learn more about our licensing.](/licensing)
 
 <Callout title="Why Envault?">
-  Traditional secret management often involves insecurely sharing `.env` files
-  over Slack or using expensive, enterprise-only SaaS solutions. Envault bridges
-  the gap: **Bank-grade security** with a **developer-first experience**,
-  completely under your control.
+  Traditional onboarding still means asking someone for a `.env` file, waiting
+  for access, and troubleshooting setup drift. Envault standardizes onboarding to
+  two commands in the repo (after one-time CLI install and project linkage):
+  `envault login` -> `envault pull`.
 </Callout>
+
+## Quickstart (10 seconds)
+
+### Phase 1 (Project Owner): Link The Repository Once
+
+```bash
+envault init
+```
+
+- `envault init`: Maps the repository to an Envault project and writes `envault.json`.
+- During init, select the default environment (for example `development`).
+- Commit `envault.json` to GitHub so every teammate gets the same project linkage and default environment context.
+
+### Phase 2 (New Teammate): 10-Second Onboarding Flow
+
+```bash
+envault login
+```
+```bash
+envault pull
+```
+
+- `envault login`: Authenticates your local CLI session.
+- `envault pull`: Uses committed `envault.json`, then pulls and decrypts project variables into your local `.env` file.
+- With GitHub JIT enabled: active repository collaborators get Viewer access on pull without a manual invite.
 
 ## Quick Links
 
@@ -68,21 +90,24 @@ Envault's repository is visible for transparency and security auditing under a p
 
 Envault isn't just a database for strings. It's a complete ecosystem for secret lifecycle management.
 
-### Security First
+### Setup Speed First
 
-Security isn't an afterthought; it's the foundation.
+Built for terminal-first onboarding and daily developer workflows.
+
+- **Two-Command Onboarding**: `envault login` followed by `envault pull`.
+- **One-Time Project Initialization**: `envault init` links the repo and stores default environment context in committed `envault.json`.
+- **GitHub JIT Access**: Repository collaborators receive automatic Viewer access during pull.
+- **Unified CLI**: A zero-dependency Go CLI for local development flows.
+- **Project Workspaces**: Isolate secrets by project (e.g., `web-app`, `backend-api`).
+
+### Security And Access Controls
+
+Security remains built in, but now as the trust layer behind fast onboarding.
 
 - **AES-256-GCM Encryption**: Utilizing a robust envelope encryption strategy.
 - **Zero-Knowledge Architecture**: Secrets are decrypted only in memory when requested.
 - **Automatic Key Rotation**: Rotate keys seamlessly without downtime.
 - **Passkey Support**: Passwordless, biometric login powered by WebAuthn.
-
-### Developer Experience
-
-Built to fit into your existing workflow, not disrupt it.
-
-- **Unified CLI**: `envault pull` is all you need to sync secrets.
-- **Project Workspaces**: Isolate secrets by project (e.g., `web-app`, `backend-api`).
 - **Team Collaboration**: Granular permissions (Owner, Editor, Viewer) for every member.
 - **Dedicated Support Page**: Integrated troubleshooting options directly within the app.
 - **Interactive Changelog**: Beautiful, animated timeline with comet scroll physics and paginated release history to keep you updated on Envault features.
@@ -99,8 +124,8 @@ Built to fit into your existing workflow, not disrupt it.
 At a high level, Envault acts as the single source of truth for your environment variables.
 
 1.  **Push**: Developers push encrypted secrets to a central project.
-2.  **Manage**: Owners control access using Role-Based Access Control (RBAC).
-3.  **Pull**: Apps and developers pull secrets into their local environments or CI/CD pipelines securely.
+2.  **Authorize**: GitHub JIT and RBAC decide who can pull.
+3.  **Pull**: Developers run `envault pull` to sync secrets locally in seconds.
 
 ## Tech Stack
 

--- a/src/components/landing/sections/CliSection.tsx
+++ b/src/components/landing/sections/CliSection.tsx
@@ -1,4 +1,4 @@
-import { Terminal, GitBranch, Zap, Shield, ArrowRight } from "lucide-react";
+import { Terminal, Github, Zap, Shield, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { AnimatedTerminal } from "@/components/landing/animations/animated-terminal";
@@ -38,9 +38,9 @@ export async function CliSection() {
 
   const workflowSteps = [
     {
-      icon: GitBranch,
-      title: "Workspace-Aware Context Switching",
-      desc: "Switch between projects and environments seamlessly. The CLI remembers your context and prevents accidental cross-project operations.",
+      icon: Github,
+      title: "GitHub JIT Onboarding",
+      desc: "Link the repo once, then collaborators get Viewer access automatically when they run `envault pull` in that workspace.",
       color: "text-blue-500",
       bg: "bg-blue-500/10",
     },
@@ -73,12 +73,13 @@ export async function CliSection() {
               </div>
 
               <h2 className="text-3xl md:text-5xl lg:text-6xl font-serif font-bold tracking-tight leading-[1.1] text-void dark:text-bone">
-                Manage Environment Variables from your Terminal.
+                Onboard developers with two commands.
               </h2>
               <p className="max-w-lg font-mono text-sm uppercase tracking-wider text-void/60 dark:text-bone/60">
-                Experience the speed of command-line secret management. Push,
-                pull, and sync your environment variables without leaving your
-                workflow.
+                ENVAULT LOGIN. ENVAULT PULL.
+                <br />
+                GITHUB JIT CHECKS REPO COLLABORATORS AND UNLOCKS VIEW ACCESS
+                INSTANTLY.
               </p>
             </SlideUp>
 

--- a/src/components/landing/sections/Features.tsx
+++ b/src/components/landing/sections/Features.tsx
@@ -59,10 +59,10 @@ export function Features() {
       <div className="container px-4 md:px-6">
         <SlideUp className="text-center mb-16 space-y-4">
           <h2 className="text-4xl md:text-6xl font-serif font-bold tracking-tight text-void dark:text-bone">
-            What Teams Choose Envault For
+            Trust Layer After The Speed
           </h2>
           <p className="max-w-[700px] mx-auto font-mono text-sm uppercase tracking-wider text-void/60 dark:text-bone/60">
-            HIGH-TRUST SECURITY / PRACTICAL DAILY OPERATIONS
+            AES-256-GCM / PASSKEYS / RBAC / AUDITABILITY
           </p>
         </SlideUp>
 

--- a/src/components/landing/sections/Hero.tsx
+++ b/src/components/landing/sections/Hero.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { ShieldCheck, ArrowRight } from "lucide-react";
+import { Timer, ArrowRight, ShieldCheck } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { InstallTerminal } from "@/components/landing/ui/install-terminal";
 import { SlideUp } from "@/components/landing/animations/SlideUp";
@@ -10,9 +10,9 @@ export function Hero() {
       <div className="container relative z-20 px-4 md:px-6 grid md:grid-cols-2 gap-12 items-center">
         <SlideUp className="flex flex-col items-start text-left space-y-8 max-w-2xl">
           <div className="flex items-center space-x-3 bg-primary/5 backdrop-blur-sm px-5 py-2 rounded-none border border-primary/10">
-            <ShieldCheck className="w-5 h-5 text-primary" />
+            <Timer className="w-5 h-5 text-primary" />
             <span className="text-sm font-mono uppercase tracking-wider text-primary">
-              MILITARY-GRADE ENCRYPTION
+              NEW DEV IN 10 SECONDS
             </span>
           </div>
 
@@ -24,11 +24,11 @@ export function Hero() {
           </h1>
 
           <p className="text-sm md:text-base lg:text-lg font-mono text-muted-foreground max-w-lg leading-relaxed border-l-2 border-primary/20 pl-4">
-            STOP MANUAL. ENV SHUFFLING.
+            STOP PASSING .ENV FILES AROUND.
             <br />
-            RUN SECRETS THROUGH CLI, SDK, AND MCP.
+            RUN `ENVAULT LOGIN` THEN `ENVAULT PULL`.
             <br />
-            HUMAN-IN-THE-LOOP APPROVALS. ZERO-KNOWLEDGE ARCHITECTURE.
+            GITHUB JIT GRANTS ACCESS FROM REPO MEMBERSHIP.
           </p>
 
           {/* Tabbed Installation UI */}
@@ -116,7 +116,7 @@ export function Hero() {
 
           <div className="flex items-center gap-2 text-xs font-mono text-muted-foreground">
             <ShieldCheck className="w-4 h-4 text-primary" />
-            <span>Secured by AES-256-GCM & Supabase Auth</span>
+            <span>Trust layer: AES-256-GCM, passkeys, and RBAC</span>
           </div>
         </SlideUp>
         {/* Right column reserved for 3D model */}

--- a/src/components/landing/sections/WorkflowSection.tsx
+++ b/src/components/landing/sections/WorkflowSection.tsx
@@ -6,25 +6,25 @@ import { FadeIn } from "@/components/landing/animations/FadeIn";
 
 const workflowSteps = [
   {
-    title: "Request Access With Scope",
+    title: "Connect Repo Once",
     description:
-      "Users request access only to the environments they need. Owners review and approve with clear scope before any secret access is granted.",
+      "Project owners run `envault init`, choose a default environment (for example `development`), and commit `envault.json` so the repo is linked and teammates can pull without `--env` flags.",
     color: "text-blue-500",
     bg: "bg-blue-500/10",
     icon: Database,
   },
   {
-    title: "Collaborate Across GitHub + Teams",
+    title: "Login And Pull",
     description:
-      "Sync secrets across teammates and repos with role-based permissions and GitHub integration built for real project workflows.",
+      "A new teammate runs `envault login` then `envault pull` inside the repo. No `.env` handoff, no manual copy/paste.",
     color: "text-green-500",
     bg: "bg-green-500/10",
     icon: Users,
   },
   {
-    title: "Trace Every Sensitive Action",
+    title: "Keep Access Auditable",
     description:
-      "Immutable audit logs and approval trails keep every pull, push, and access decision accountable for operational and security review.",
+      "RBAC, approvals, and audit logs keep every pull and permission change accountable after onboarding is complete.",
     color: "text-purple-500",
     bg: "bg-purple-500/10",
     icon: Shield,
@@ -37,32 +37,32 @@ export function WorkflowSection() {
       <div className="container px-4 md:px-6">
         <SlideUp className="text-center mb-16 space-y-4">
           <h2 className="text-3xl md:text-5xl lg:text-6xl font-serif font-bold tracking-tight text-foreground leading-[1.1]">
-            Strong access control,
+            From zero setup to synced secrets
             <br />
-            without slowing teams down.
+            in about 10 seconds.
           </h2>
           <p className="max-w-[700px] mx-auto font-mono text-sm uppercase tracking-wider text-muted-foreground">
-            REQUEST. APPROVE. SYNC. AUDIT.
+            LINK. LOGIN. PULL. SHIP.
             <br />
-            THE CORE FLOW YOUR TEAM NEEDS EVERY DAY.
+            BUILT FOR DAILY DEVELOPER ONBOARDING.
           </p>
         </SlideUp>
 
-        <div className="grid lg:grid-cols-2 gap-8 lg:gap-12 items-center mb-16">
+        <div className="grid lg:grid-cols-2 gap-8 lg:gap-12 lg:items-stretch mb-16">
           {/* Left Column: Image Placeholder */}
-          <FadeIn className="relative border border-border min-h-[250px] sm:min-h-[300px] md:min-h-[350px] aspect-square sm:aspect-[5/4] lg:aspect-auto max-h-[500px] lg:max-h-none">
+          <FadeIn className="relative border border-border min-h-[250px] sm:min-h-[300px] md:min-h-[350px] aspect-square sm:aspect-[5/4] lg:aspect-auto lg:h-full max-h-[500px] lg:max-h-none">
             <AnimatedWorkflow />
           </FadeIn>
 
           {/* Right Column: Workflow Steps */}
-          <div className="space-y-4">
+          <div className="grid gap-4 auto-rows-fr lg:h-full">
             {workflowSteps.map((step, index) => (
               <SlideUp
                 key={index}
                 delay={index * 0.15}
-                className="group border border-border p-3 md:p-6 rounded-none bg-background hover:bg-secondary/30 transition-colors"
+                className="group h-full border border-border p-3 md:p-6 rounded-none bg-background hover:bg-secondary/30 transition-colors"
               >
-                <div className="flex items-start space-x-4 md:space-x-6">
+                <div className="flex h-full items-start space-x-4 md:space-x-6">
                   <div
                     className={`p-3 md:p-4 rounded-none ${step.bg} ${step.color} flex-shrink-0 border border-black/5 dark:border-white/5`}
                   >


### PR DESCRIPTION
This pull request updates the Envault documentation and landing page to focus on fast developer onboarding and the new GitHub Just-in-Time (JIT) access flow. Messaging now emphasizes a two-command onboarding process (`envault login` and `envault pull`), replacing the previous focus on manual `.env` sharing and generic secret management. The changes improve clarity for new users and better communicate Envault’s unique value for teams.

**Landing Page and Documentation Messaging Overhaul**

* Major content and copy updates across docs and landing sections to highlight the new onboarding flow, two-command setup, and GitHub JIT access. 
**Feature and Workflow Section Updates**

* Updated workflow and feature descriptions to reflect the new onboarding-first approach, replacing references to manual approval and access requests with automated GitHub-based flows. 

**Visual and Iconography Changes**

* Replaced and updated icons (e.g., using `Timer` and `Github` icons) to match the new onboarding and speed messaging. 

**Technical Details and Security Messaging**

* Updated technical and security messaging to clarify that security remains foundational but is now positioned as the trust layer supporting fast onboarding (AES-256-GCM, passkeys, RBAC, etc.). 

**Quickstart and Getting Started Instructions**

* Added a prominent quickstart section in the docs, outlining the one-time project linking and the 10-second onboarding flow for new teammates.

These changes collectively modernize Envault’s positioning, making it clear that the platform is optimized for rapid, secure onboarding of developers to project secrets with minimal friction.

---
Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>