### PR TITLE
Enhance security documentation for agent control and auditability

### DIFF
--- a/content/docs/platform/core/security.mdx
+++ b/content/docs/platform/core/security.mdx
@@ -44,3 +44,16 @@ When utilizing Envault's SDK or MCP for automated AI workflows, multiple securit
 - **Project Isolation**: Agents are strictly fenced to the project explicitly defined in your `.vscode/mcp.json` or SDK initialization script.
 - **Human-in-the-Loop (HITL)**: Crucial mutations (e.g., an AI attempting to overwrite your production `STRIPE_SECRET_KEY`) require explicit approval from a human Project Owner or Editor via the UI or CLI `approve` command before execution.
 - **Kill Switches**: You maintain ultimate control. Agent integration can be instantly severed via your user Security Settings (global) or specific Project Settings (isolated).
+
+## Verifiable Agent Control Surface (Hybrid Open Source)
+
+Envault uses a hybrid model: the cloud core is proprietary, while the agent execution layer is open for inspection.
+
+- `mcp-server/` is MIT-licensed and fully auditable.
+- `src/lib/sdk/` is MIT-licensed and fully auditable.
+
+This architecture is a direct DX advantage for security-conscious teams:
+
+- You can independently audit the exact HITL interception implementation.
+- You can inspect short-lived delegated `envault_agt_` JWT handling in code.
+- You can verify that mutation execution remains approval-gated and cannot bypass human controls through opaque runtime behavior.

--- a/content/docs/platform/guides/mcp-agents.mdx
+++ b/content/docs/platform/guides/mcp-agents.mdx
@@ -8,6 +8,19 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 This guide is for local AI assistants (Claude Desktop, Cursor, Windsurf, Cline) using Envault MCP.
 
+## Open execution layer, verifiable control
+
+Envault runs a hybrid open-source model: the cloud control plane is proprietary, and the execution layer is fully auditable.
+
+- `mcp-server/` is MIT-licensed and open source.
+- `src/lib/sdk/` is MIT-licensed and open source.
+
+Why this is a DX win:
+
+- You can audit the exact Human-In-The-Loop (HITL) interception path used by local agents.
+- You can inspect delegated token handling end-to-end, including the short-lived `envault_agt_` JWT flow.
+- You can verify in code that agent mutation calls are routed into approval-first behavior, not silent file/database mutation.
+
 When you run `envault mcp install`, Envault provisions a **project-scoped delegated JWT** (`envault_agt_`) with a **1-hour lifetime**. The agent gets only scoped access for that project, not unrestricted account-wide access.
 
 <Callout type="info">
@@ -66,6 +79,8 @@ When an AI attempts a mutation (for example: creating or updating a secret using
 4. MCP surfaces a secure **Approval Link** back in your AI chat UI.
 5. You open the link, review the exact proposed keys/values in the dashboard, and click **Approve**. Alternatively, you can approve from your terminal using `envault approve <approval_id>`, which now provides a visual cryptographic diff to prevent blind executions.
 6. Envault then encrypts and applies the change.
+
+Because the MCP server and SDK execution code are MIT-open, you can independently validate the delegated `envault_agt_` minting and verification logic in your own review pipeline.
 
 <Callout type="warn">
   No approval means no mutation is executed.

--- a/content/docs/platform/guides/sdk-mcp-agent-workflows.mdx
+++ b/content/docs/platform/guides/sdk-mcp-agent-workflows.mdx
@@ -11,6 +11,19 @@ Use this page if you need **manual MCP wiring** or an explicit reference for too
 
 For the direct local setup flow (`envault mcp install`) and the delegated `envault_agt_` + HITL walkthrough, use [Local AI Agents (Claude & Cursor)](/docs/platform/guides/mcp-agents).
 
+## Hybrid model: proprietary core, open execution layer
+
+Envault's cloud platform is proprietary. The runtime surfaces that execute agent actions are intentionally open:
+
+- `mcp-server/` is fully open source under MIT.
+- `src/lib/sdk/` is fully open source under MIT.
+
+This gives engineering teams a concrete control surface to audit:
+
+- The HITL interceptor path for mutation requests.
+- The delegated short-lived token architecture (`envault_agt_` JWT lifecycle).
+- The approval-first sequencing that prevents agents from bypassing human approval.
+
 <Callout type="info">
   This page is intentionally advanced. It complements the quickstart guide and avoids duplicating it.
 </Callout>
@@ -118,6 +131,8 @@ When an agent requests a mutation, Envault executes the same approval sequence b
    **Note:** The `approve` command now provides a cryptographic visual diff directly in your terminal, outlining Additions (+), Deletions (-), and Modifications (~). You must be in an interactive terminal to approve the change, otherwise it fails to prevent blind execution.
 
 5. **Execution:** Once approved, the mutation is securely executed, and the agent proceeds with its task.
+
+The delegated token path is also verifiable in source: agent runtime calls only proceed with scoped, short-lived `envault_agt_` credentials, and mutation execution remains gated behind explicit HITL approval.
 
 <Callout type="info">
   All agent requests, approvals, and rejections are permanently recorded in your

--- a/src/components/landing/sections/PlatformHighlights.tsx
+++ b/src/components/landing/sections/PlatformHighlights.tsx
@@ -13,13 +13,13 @@ const highlights = [
   },
   {
     icon: Bot,
-    title: "Approve Agent Actions In Real Time",
-    desc: "Keep human-in-the-loop control for sensitive operations while still enabling fast machine-assisted workflows.",
+    title: "Open-Source Agent Execution Layer",
+    desc: "Envault's core cloud is proprietary, but the editor-facing execution path is open under MIT so teams can inspect exactly what runs locally.",
   },
   {
     icon: PackageCheck,
-    title: "Versioned Releases For Stable Integration",
-    desc: "SDK and MCP are shipped as independently versioned packages so teams can adopt updates intentionally.",
+    title: "Audit HITL + Delegated JWT Flow",
+    desc: "The MIT-licensed MCP and SDK code lets you verify envault_agt_ short-lived token gating and approval-first mutation behavior.",
   },
 ];
 

--- a/src/lib/data/seo-content.ts
+++ b/src/lib/data/seo-content.ts
@@ -28,7 +28,7 @@ export const comparisonPages: SeoPageData[] = [
       },
       {
         heading: 'Native AI Agent Support',
-        content: 'The future of development involves AI agents interacting with your codebase. Envault is built with native Model Context Protocol (MCP) server support, allowing autonomous agents to securely access necessary environment context without exposing raw keys. Doppler leaves you building manual workarounds.'
+        content: 'Envault ships native MCP support with a hybrid open-source execution layer. The cloud core is proprietary, but the MIT-licensed mcp-server/ and src/lib/sdk/ paths are fully auditable, including the HITL interceptor and short-lived envault_agt_ delegated JWT flow. Your team gets AI speed with verifiable human control.'
       },
       {
         heading: 'Lightweight and Blazing Fast',

--- a/src/lib/sdk/cli-tool-definition.generated.json
+++ b/src/lib/sdk/cli-tool-definition.generated.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-03T19:20:41.815Z",
+  "generatedAt": "2026-05-04T13:49:47.960Z",
   "sourceDir": "cli-go/cmd",
   "commands": [
     {
@@ -307,6 +307,11 @@
           "name": "file",
           "usage": "Local .env file path override",
           "persistent": false
+        },
+        {
+          "name": "timeout",
+          "usage": "Maximum duration for API retry/wait behavior (e.g. 30s, 2m). Overrides ENVAULT_RETRY_MAX_DURATION.",
+          "persistent": false
         }
       ],
       "parentVar": "rootCmd",
@@ -323,6 +328,11 @@
           "name": "project",
           "short": "p",
           "usage": "Project ID",
+          "persistent": false
+        },
+        {
+          "name": "timeout",
+          "usage": "Maximum duration for API retry/wait behavior (e.g. 30s, 2m). Overrides ENVAULT_RETRY_MAX_DURATION.",
           "persistent": false
         }
       ],


### PR DESCRIPTION
This pull request introduces and documents a new hybrid open-source architecture for Envault's agent execution layer, emphasizing security, auditability, and developer control. It also updates the product's messaging to highlight the MIT-licensed, auditable components and the verifiable Human-In-The-Loop (HITL) and delegated JWT flow. Additionally, the CLI tool definition is updated to support a new timeout option for API operations.

**Documentation and Messaging Updates:**

* Added detailed explanations in multiple docs (`security.mdx`, `mcp-agents.mdx`, `sdk-mcp-agent-workflows.mdx`) about Envault's hybrid model: the cloud core remains proprietary, but the agent execution layer (`mcp-server/`, `src/lib/sdk/`) is MIT-licensed and open source, enabling teams to audit HITL interception, delegated JWT handling, and approval gating. 
* Updated landing page highlights and SEO content to reflect the new open-source execution layer, auditable HITL and JWT flows, and the developer experience benefits of this architecture. 
* Enhanced guides to clarify that the delegated token and approval-first mutation paths are verifiable in open source, reinforcing trust in the platform's security model. 

**CLI Tooling:**

* Added a new `timeout` option to the CLI tool definition, allowing users to specify the maximum duration for API retry/wait behavior, with the ability to override the `ENVAULT_RETRY_MAX_DURATION` environment variable. 
* Updated the CLI tool definition's `generatedAt` timestamp to reflect the latest build.

---
Co-authored-by: Rajat Patra <113469515+RawJat@users.noreply.github.com>